### PR TITLE
Updates kubectl mechanisms to save a kubeconfig file to a temp directory

### DIFF
--- a/cmd/hope/reset.go
+++ b/cmd/hope/reset.go
@@ -42,6 +42,8 @@ var resetCmd = &cobra.Command{
 			return err
 		}
 
+		defer kubectl.Destroy()
+
 		// TODO: may need to add more validation, like that this isn't the
 		//   only master and is being removed, unless force is provided.
 		return hope.KubeadmResetRemote(log.WithFields(log.Fields{}), kubectl, host, resetCmdForce)

--- a/cmd/hope/root.go
+++ b/cmd/hope/root.go
@@ -129,15 +129,15 @@ func initLogger() {
 
 func patchInvocations() {
 	oldExecKubectl := kubeutil.ExecKubectl
-	kubeutil.ExecKubectl = func(args ...string) error {
+	kubeutil.ExecKubectl = func(kubectl *kubeutil.Kubectl, args ...string) error {
 		log.Debug("kubectl ", strings.Join(args, " "))
-		return oldExecKubectl(args...)
+		return oldExecKubectl(kubectl, args...)
 	}
 
 	oldGetKubectl := kubeutil.GetKubectl
-	kubeutil.GetKubectl = func(args ...string) (string, error) {
+	kubeutil.GetKubectl = func(kubectl *kubeutil.Kubectl, args ...string) (string, error) {
 		log.Debug("kubectl ", strings.Join(args, " "))
-		return oldGetKubectl(args...)
+		return oldGetKubectl(kubectl, args...)
 	}
 
 	oldExecScp := scp.ExecSCP

--- a/cmd/hope/utils.go
+++ b/cmd/hope/utils.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"errors"
+)
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+import (
+	"github.com/Eagerod/hope/pkg/hope"
+	"github.com/Eagerod/hope/pkg/kubeutil"
+)
+
+// Loops through the list of hosts in order, and attempts to fetch a
+//   kubeconfig file that will allow access to the cluster.
+func getKubectlFromAnyMaster(log *logrus.Entry, masters []string) (*kubeutil.Kubectl, error) {
+	for _, host := range masters {
+		log.Debug("Trying to fetch kubeconfig from host ", host, " from masters list")
+		kubectl, err := hope.GetKubectl(host)
+		if err == nil {
+			return kubectl, nil
+		}
+	}
+
+	return nil, errors.New("Failed to find a kubeconfig file on any host")
+}

--- a/hope.yaml
+++ b/hope.yaml
@@ -2,4 +2,4 @@ masters:
   - root@192.168.200.10
 nodes:
   - root@192.168.200.11
-loglevel: "trace"
+loglevel: trace

--- a/pkg/hope/remote_kubeadm.go
+++ b/pkg/hope/remote_kubeadm.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Eagerod/hope/pkg/ssh"
 )
 
-func KubeadmResetRemote(log *logrus.Entry, host string, force bool) error {
+func KubeadmResetRemote(log *logrus.Entry, kubectl *kubeutil.Kubectl, host string, force bool) error {
 	// URL parsing is a bit better at identifying parameters if there's a
 	//   protocol on the string passed in, so fake in ssh as the protocol to
 	//   help it parse a little more reliably.
@@ -27,7 +27,7 @@ func KubeadmResetRemote(log *logrus.Entry, host string, force bool) error {
 
 	log.Debug("Searching for node name for host: ", host_url.Host)
 
-	nodesOutput, err := kubeutil.GetKubectl("get", "nodes", "-o", "custom-columns=NODE:metadata.name,IP:status.addresses[?(@.type=='InternalIP')].address")
+	nodesOutput, err := kubeutil.GetKubectl(kubectl, "get", "nodes", "-o", "custom-columns=NODE:metadata.name,IP:status.addresses[?(@.type=='InternalIP')].address")
 	if err != nil {
 		log.Error(nodesOutput)
 		return err
@@ -54,7 +54,7 @@ func KubeadmResetRemote(log *logrus.Entry, host string, force bool) error {
 	} else {
 		log.Info("Draining node ", nodeName, " from the cluster")
 
-		if err := kubeutil.ExecKubectl("drain", nodeName, "--ignore-daemonsets"); err != nil {
+		if err := kubeutil.ExecKubectl(kubectl, "drain", nodeName, "--ignore-daemonsets"); err != nil {
 			return err
 		}
 	}
@@ -65,7 +65,7 @@ func KubeadmResetRemote(log *logrus.Entry, host string, force bool) error {
 	}
 
 	if nodeName != "" {
-		if err := kubeutil.ExecKubectl("delete", "node", nodeName); err != nil {
+		if err := kubeutil.ExecKubectl(kubectl, "delete", "node", nodeName); err != nil {
 			return err
 		}
 	}

--- a/pkg/kubeutil/kubeutil.go
+++ b/pkg/kubeutil/kubeutil.go
@@ -1,6 +1,7 @@
 package kubeutil
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path"
@@ -10,19 +11,35 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 )
 
-type GetKubeutilFunc func(args ...string) (string, error)
-type ExecKubeutilFunc func(args ...string) error
+// Kubectl struct allows for execution of a kubectl command with a
+//   non-environment set kubeconfig path.
+type Kubectl struct {
+	KubeconfigPath string
+}
 
-var GetKubectl GetKubeutilFunc = func(args ...string) (string, error) {
+func NewKubectl(kubeconfigPath string) *Kubectl {
+	return &Kubectl{kubeconfigPath}
+}
+
+func (kubectl *Kubectl) Destroy() error {
+	return os.Remove(kubectl.KubeconfigPath)
+}
+
+type GetKubectlFunc func(kubectl *Kubectl, args ...string) (string, error)
+type ExecKubectlFunc func(kubectl *Kubectl, args ...string) error
+
+var GetKubectl GetKubectlFunc = func(kubectl *Kubectl, args ...string) (string, error) {
 	osCmd := exec.Command("kubectl", args...)
+    osCmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubectl.KubeconfigPath))
 	osCmd.Stdin = os.Stdin
 	output, err := osCmd.CombinedOutput()
 
 	return string(output), err
 }
 
-var ExecKubectl ExecKubeutilFunc = func(args ...string) error {
+var ExecKubectl ExecKubectlFunc = func(kubectl *Kubectl, args ...string) error {
 	osCmd := exec.Command("kubectl", args...)
+    osCmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubectl.KubeconfigPath))
 	osCmd.Stdin = os.Stdin
 	osCmd.Stdout = os.Stdout
 	osCmd.Stderr = os.Stderr


### PR DESCRIPTION
Allows for these configs to be held more ephemerally, rather than requiring them to
overwrite the user's own ~/.kube/config