### PR TITLE
Updates kubeconfig command to work without arguments.

### DIFF
--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -1,0 +1,75 @@
+package fileutil
+
+import (
+	"crypto/md5"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+func CopyFileMode(src string, dst string, fileMode os.FileMode) error {
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		return errors.New(fmt.Sprintf("Refusing to overwrite existing file (%s)", dst))
+	}
+
+	srcFile, err := ioutil.ReadFile(src)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(dst, srcFile, fileMode)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func CopyFile(src string, dst string) error {
+	return CopyFileMode(src, dst, 0644)
+}
+
+func MD5Path(path string) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return []byte{}, err
+	}
+	defer file.Close()
+
+	hash := md5.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return []byte{}, err
+	}
+
+	return hash.Sum(nil), nil
+}
+
+func FilesIdentical(f1 string, f2 string) (bool, error) {
+	f1Stat, err := os.Stat(f1)
+	if err != nil {
+		return false, err
+	}
+
+	f2Stat, err := os.Stat(f2)
+	if err != nil {
+		return false, err
+	}
+
+	if f1Stat.Size() != f2Stat.Size() {
+		return false, nil
+	}
+
+	f1Hash, err := MD5Path(f1)
+	if err != nil {
+		return false, err
+	}
+
+	f2Hash, err := MD5Path(f2)
+	if err != nil {
+		return false, err
+	}
+
+	return string(f1Hash) == string(f2Hash), nil
+}

--- a/pkg/hope/remote_kubeconfig.go
+++ b/pkg/hope/remote_kubeconfig.go
@@ -12,6 +12,7 @@ import (
 )
 
 import (
+	"github.com/Eagerod/hope/pkg/fileutil"
 	"github.com/Eagerod/hope/pkg/kubeutil"
 	"github.com/Eagerod/hope/pkg/scp"
 )
@@ -45,20 +46,36 @@ func FetchKubeconfig(log *logrus.Entry, host string, merge bool) error {
 		return err
 	}
 
-	// If the file already exists, and merge isn't provided, bail.
-	log.Trace("Local KUBECONFIG filepath: ", kubeconfigFile)
-	if _, err := os.Stat(kubeconfigFile); err == nil {
-		if !merge {
-			return errors.New("Refusing to overwrite existing kubeconfig file.")
-		}
-	}
-
 	kubectl, err := GetKubectl(host)
 	if err != nil {
 		return err
 	}
 
 	defer kubectl.Destroy()
+
+	// If the file already exists, and merge isn't provided, bail.
+	// TODO: Test if local kubeconfig path is actually pointing at multiple
+	//   files, and fail gracefully for that.
+	log.Trace("Local KUBECONFIG filepath: ", kubeconfigFile)
+	if _, err := os.Stat(kubeconfigFile); err == nil {
+		if same, _ := fileutil.FilesIdentical(kubeconfigFile, kubectl.KubeconfigPath); same {
+			log.Info("File pulled from remote identical to local file. Skipping overwrite.")
+			return nil
+		}
+
+		if !merge {
+			return errors.New("Refusing to overwrite existing kubeconfig file.")
+		}
+	} else if os.IsNotExist(err) {
+		log.Debug("Local kubeconfig file does not exist. Writing new file.")
+		if err := fileutil.CopyFileMode(kubectl.KubeconfigPath, kubeconfigFile, 0600); err != nil {
+			return err
+		}
+
+		return nil
+	} else {
+		return err
+	}
 
 	log.Debug("Merging existing KUBECONFIG file with file downloaded from ", host)
 


### PR DESCRIPTION
Also fixes up always using merge logic, even when there's no file to merge with.