### PR TITLE
Follow logs of a job when deployed

### DIFF
--- a/cmd/hope/deploy.go
+++ b/cmd/hope/deploy.go
@@ -149,7 +149,7 @@ var deployCmd = &cobra.Command{
 						// If the job is running, start polling for logs.
 						// Jobs that failed or completed long in the past may
 						//   have had their pods wiped since they ran.
-						if err := hope.AttachToLogsIfContainersRunning(kubectl, resource.Job); err != nil {
+						if err := hope.FollowLogsIfContainersRunning(kubectl, resource.Job); err != nil {
 							log.Warn(err)
 							attemptsDuration := math.Pow(2, float64(attempts-1))
 							sleepSeconds := int(math.Min(attemptsDuration, float64(MaximumJobDeploymentPollSeconds)))

--- a/cmd/hope/deploy.go
+++ b/cmd/hope/deploy.go
@@ -21,6 +21,8 @@ import (
 	"github.com/Eagerod/hope/pkg/kubeutil"
 )
 
+const MaximumJobDeploymentPollSeconds int = 60
+
 // rootCmd represents the base command when called without any subcommands
 var deployCmd = &cobra.Command{
 	Use:   "deploy",
@@ -150,9 +152,9 @@ var deployCmd = &cobra.Command{
 						if err := hope.AttachToLogsIfContainersRunning(kubectl, resource.Job); err != nil {
 							log.Warn(err)
 							attemptsDuration := math.Pow(2, float64(attempts-1))
-							sleepSeconds := int(math.Min(attemptsDuration, 12))
+							sleepSeconds := int(math.Min(attemptsDuration, float64(MaximumJobDeploymentPollSeconds)))
 					
-							if sleepSeconds == 12 {
+							if sleepSeconds == MaximumJobDeploymentPollSeconds {
 								log.Debug("Checking pod events for details...")
 								// Check the event log for the pods associated
 								//   with this job.

--- a/pkg/hope/kubectl_jobs.go
+++ b/pkg/hope/kubectl_jobs.go
@@ -39,7 +39,7 @@ func GetJobStatus(log *logrus.Entry, kubectl *kubeutil.Kubectl, job string) (Job
 	}
 }
 
-func AttachToLogsIfContainersRunning(kubectl *kubeutil.Kubectl, job string) error {
+func FollowLogsIfContainersRunning(kubectl *kubeutil.Kubectl, job string) error {
 	jobSelector := fmt.Sprintf("job-name=%s", job)
 	
 	// Wait for this loop to finish without failure.

--- a/pkg/hope/kubectl_jobs.go
+++ b/pkg/hope/kubectl_jobs.go
@@ -1,0 +1,59 @@
+package hope
+
+import (
+	"fmt"
+	"strings"
+)
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+import (
+	"github.com/Eagerod/hope/pkg/kubeutil"
+)
+
+type JobStatus int
+
+const (
+	JobStatusUnknown JobStatus = 0
+	JobStatusRunning = 1
+	JobStatusComplete = 2
+	JobStatusFailed = 3
+)
+
+// Check to see if the provided job has completed, or is still running.
+func GetJobStatus(log *logrus.Entry, kubectl *kubeutil.Kubectl, job string) (JobStatus, error) {
+	output, err := kubeutil.GetKubectl(kubectl, "get", "job", job, "-o", "template={{range .status.conditions}}{{.type}}{{end}}")
+	if err != nil {
+		return JobStatusUnknown, err
+	}
+
+	switch output {
+	case "Complete":
+		return JobStatusComplete, nil
+	case "Failed":
+		return JobStatusFailed, nil
+	default:
+		return JobStatusRunning, nil		
+	}
+}
+
+func AttachToLogsIfContainersRunning(kubectl *kubeutil.Kubectl, job string) error {
+	jobSelector := fmt.Sprintf("job-name=%s", job)
+	
+	// Wait for this loop to finish without failure.
+	// Exponential backoff for re-attempts, max 12 seconds
+	return kubeutil.ExecKubectl(kubectl, "logs", "-f", "-l", jobSelector)
+}
+
+func GetPodsForJob(kubectl *kubeutil.Kubectl, job string) (*[]string, error) {
+	jobSelector := fmt.Sprintf("job-name=%s", job)
+	output, err := kubeutil.GetKubectl(kubectl, "get", "pods", "-l", jobSelector, "-o", "template={{range .items}}{{.metadata.name}}{{end}}")
+	if err != nil {
+		return nil, err
+	}
+
+	pods := strings.Split(output, "\n")
+	return &pods, nil
+}

--- a/pkg/kubeutil/kubectl.go
+++ b/pkg/kubeutil/kubectl.go
@@ -1,0 +1,21 @@
+package kubeutil
+
+import (
+	"os"
+)
+
+// Kubectl struct allows for execution of a kubectl command with a
+//   non-environment set kubeconfig path.
+// TODO: Move more uses of kubeutil.ExecKubectl/GetKubectl/etc to use this
+//   structure.
+type Kubectl struct {
+	KubeconfigPath string
+}
+
+func NewKubectl(kubeconfigPath string) *Kubectl {
+	return &Kubectl{kubeconfigPath}
+}
+
+func (kubectl *Kubectl) Destroy() error {
+	return os.Remove(kubectl.KubeconfigPath)
+}

--- a/pkg/kubeutil/kubeutil.go
+++ b/pkg/kubeutil/kubeutil.go
@@ -13,24 +13,6 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 )
 
-// Kubectl struct allows for execution of a kubectl command with a
-//   non-environment set kubeconfig path.
-// TODO: Set up methods on Kubectl that invocations look like this:
-//   kubectl.GetPods(...)
-// rather than
-//   kubeutil.ExecKubectl(kubectl, "get", "pods", ...)
-type Kubectl struct {
-	KubeconfigPath string
-}
-
-func NewKubectl(kubeconfigPath string) *Kubectl {
-	return &Kubectl{kubeconfigPath}
-}
-
-func (kubectl *Kubectl) Destroy() error {
-	return os.Remove(kubectl.KubeconfigPath)
-}
-
 type GetKubectlFunc func(kubectl *Kubectl, args ...string) (string, error)
 type ExecKubectlFunc func(kubectl *Kubectl, args ...string) error
 type InKubectlFunc func(kubectl *Kubectl, stdin string, args ...string) error


### PR DESCRIPTION
Updates the Job deployment process to print logs as the job runs, so progress can be monitored.

Updates to seek out events from pods in a job in the case where it fails a bunch of times.