### PR TITLE
Updates so that parameters must be given to populate values in inline scripts.

### DIFF
--- a/cmd/hope/deploy.go
+++ b/cmd/hope/deploy.go
@@ -18,8 +18,6 @@ import (
 	"github.com/Eagerod/hope/pkg/hope"
 )
 
-const MaximumJobDeploymentPollSeconds int = 60
-
 var deployCmd = &cobra.Command{
 	Use:   "deploy",
 	Short: "Deploy a Kubernetes yaml file",
@@ -113,9 +111,14 @@ var deployCmd = &cobra.Command{
 				//   are likely being populated.
 				log.Trace(inline)
 
-				inline, err := envsubst.GetEnvsubst(inline)
-				if err != nil {
-					return err
+				if len(resource.Parameters) != 0 {
+					log.Trace("Populating parameters: ", strings.Join(resource.Parameters, ", "))
+					inline, err = envsubst.GetEnvsubstArgsFromEnv(resource.Parameters, inline)
+					if err != nil {
+						return err
+					}
+				} else {
+					log.Trace(resource.Name, " does not have any parameters. Skipping envsubst.")
 				}
 
 				if err := hope.KubectlApplyStdIn(kubectl, inline); err != nil {

--- a/cmd/hope/root.go
+++ b/cmd/hope/root.go
@@ -164,6 +164,12 @@ func patchInvocations() {
 		return oldEnvSubstArgs(args, str)
 	}
 
+	oldEnvSubstArgsFromEnv := envsubst.GetEnvsubstArgsFromEnv
+	envsubst.GetEnvsubstArgsFromEnv = func(args []string, str string) (string, error) {
+		log.Debug("echo **(", len(str), " chars)** | envsubst ", strings.Join(args, ","))
+		return oldEnvSubstArgsFromEnv(args, str)
+	}
+
 	oldExecKubectl := kubeutil.ExecKubectl
 	kubeutil.ExecKubectl = func(kubectl *kubeutil.Kubectl, args ...string) error {
 		log.Debug("kubectl ", strings.Join(args, " "))

--- a/cmd/hope/root.go
+++ b/cmd/hope/root.go
@@ -166,7 +166,12 @@ func patchInvocations() {
 
 	oldEnvSubstArgsFromEnv := envsubst.GetEnvsubstArgsFromEnv
 	envsubst.GetEnvsubstArgsFromEnv = func(args []string, str string) (string, error) {
-		log.Debug("echo **(", len(str), " chars)** | envsubst ", strings.Join(args, ","))
+		argsKeys := []string{}
+		for _, key := range args {
+			argsKeys = append(argsKeys, fmt.Sprintf("$%s", key))
+		}
+
+		log.Debug("echo **(", len(str), " chars)** | envsubst ", strings.Join(argsKeys, ","))
 		return oldEnvSubstArgsFromEnv(args, str)
 	}
 

--- a/cmd/hope/utils.go
+++ b/cmd/hope/utils.go
@@ -30,11 +30,12 @@ type BuildSpec struct {
 }
 
 type Resource struct {
-	Name   string
-	File   string
-	Inline string
-	Build  BuildSpec
-	Job    string
+	Name       string
+	File       string
+	Inline     string
+	Parameters []string
+	Build      BuildSpec
+	Job        string
 }
 
 // TODO: Allow jobs to define max retry parameters, or accept them on the

--- a/hope.yaml
+++ b/hope.yaml
@@ -22,6 +22,9 @@ resources:
   # Values passed in through `inline` will be fed through `envsubst` before
   #   being passed off to kubectl, so any values that are dynamic/secret can be
   #   passed in through using environment variables.
+  # Values that envsubst will be required to populate are provided in the
+  #   parameters list.
+  # If no parameters are provided, envsubst is skipped.
   # As is the case with anything else hitting kubectl apply -f, multiple
   #   objects can be provided by --- separators.
   - name: load-balancer-config
@@ -47,6 +50,8 @@ resources:
         creationTimestamp: null
         name: memberlist
         namespace: metallb-system
+    parameters:
+      - METALLB_SYSTEM_MEMBERLIST_SECRET_KEY
   # Build and push a docker image to the registry.
   # Doesn't include a kubectl command at all, so that can be done in a step
   #   after a step like this appears.

--- a/pkg/envsubst/envsubst.go
+++ b/pkg/envsubst/envsubst.go
@@ -1,6 +1,7 @@
 package envsubst
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -9,6 +10,7 @@ import (
 
 type GetEnvsubstStringFunc func(str string) (string, error)
 type GetEnvsubstStringArgsFunc func(args map[string]string, str string) (string, error)
+type GetEnvsubstStringArgsFromEnvFunc func(args []string, str string) (string, error)
 
 var GetEnvsubst GetEnvsubstStringFunc = func(str string) (string, error) {
 	osCmd := exec.Command("envsubst")
@@ -32,6 +34,29 @@ var GetEnvsubstArgs GetEnvsubstStringArgsFunc = func(args map[string]string, str
 		osCmd.Env = append(osCmd.Env, fmt.Sprintf("%s=%s", key, value))
 	}
 
+	osCmd.Stdin = strings.NewReader(str)
+	osCmd.Stderr = os.Stderr
+
+	outputBytes, err := osCmd.Output()
+	return string(outputBytes), err
+}
+
+var GetEnvsubstArgsFromEnv GetEnvsubstStringArgsFromEnvFunc = func(args []string, str string) (string, error) {
+	if len(args) == 0 {
+		return str, nil
+	}
+
+	// If any argument isn't given, return an error
+	argsKeys := []string{}
+	for _, key := range args {
+		_, exists := os.LookupEnv(key)
+		if !exists {
+			return "", errors.New(fmt.Sprintf("Failed to find %s in environment.", key))
+		}
+		argsKeys = append(argsKeys, fmt.Sprintf("$%s", key))
+	}
+
+	osCmd := exec.Command("envsubst", strings.Join(argsKeys, ","))
 	osCmd.Stdin = strings.NewReader(str)
 	osCmd.Stderr = os.Stderr
 


### PR DESCRIPTION
Right now, it's not possible to define inline scripts that contain values that look like environment variables. This brings a similar structure as exists in the run job mechanism.