### PR TITLE
Implement resource tagging to deploy groups of resources easily.

### DIFF
--- a/cmd/hope/deploy.go
+++ b/cmd/hope/deploy.go
@@ -22,7 +22,7 @@ import (
 var deployCmdTagSlice *[]string
 
 func initDeployCmdFlags() {
-	deployCmdTagSlice = runCmd.Flags().StringArrayP("tags", "t", []string{}, "tags to deploy")
+	deployCmdTagSlice = deployCmd.Flags().StringArrayP("tags", "t", []string{}, "tags to deploy")
 }
 
 var deployCmd = &cobra.Command{

--- a/cmd/hope/deploy.go
+++ b/cmd/hope/deploy.go
@@ -73,7 +73,6 @@ var deployCmd = &cobra.Command{
 		} else {
 			log.Debug("Deploying these resources: \n\t", strings.Join(args, "\n\t"), "\nIn the order given.")
 
-			// TODO: Lots of duplicated code; maybe a helper?
 			// Map the slice by name so they can be fetched in order.
 			resourcesMap := map[string]Resource{}
 			for _, resource := range *resources {

--- a/cmd/hope/deploy.go
+++ b/cmd/hope/deploy.go
@@ -22,7 +22,7 @@ import (
 var deployCmdTagSlice *[]string
 
 func initDeployCmdFlags() {
-	deployCmdTagSlice = deployCmd.Flags().StringArrayP("tags", "t", []string{}, "tags to deploy")
+	deployCmdTagSlice = deployCmd.Flags().StringArrayP("tag", "t", []string{}, "deploy resources with this tag")
 }
 
 var deployCmd = &cobra.Command{

--- a/cmd/hope/deploy.go
+++ b/cmd/hope/deploy.go
@@ -19,13 +19,24 @@ import (
 	"github.com/Eagerod/hope/pkg/kubeutil"
 )
 
+var deployCmdTagSlice *[]string
+
+func initDeployCmdFlags() {
+	deployCmdTagSlice = runCmd.Flags().StringArrayP("tags", "t", []string{}, "tags to deploy")
+}
+
 var deployCmd = &cobra.Command{
 	Use:   "deploy",
-	Short: "Deploy a Kubernetes yaml file",
+	Short: "Deploy Kubernetes resources defined in the hope file",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		resources, err := getResources()
 		if err != nil {
 			return err
+		}
+
+		// TODO: Re-evaluate; maybe just deploy everything in order defined.
+		if len(args) != 0 && len(*deployCmdTagSlice) != 0 {
+			return errors.New("Cannot deploy tags and named resources together.")
 		}
 
 		masters := viper.GetStringSlice("masters")
@@ -39,11 +50,30 @@ var deployCmd = &cobra.Command{
 		resourcesToDeploy := []Resource{}
 
 		if len(args) == 0 {
-			log.Debug("Received no arguments for deployment. Deploying all resources.")
-			resourcesToDeploy = *resources
+			if len(*deployCmdTagSlice) != 0 {
+				tagMap := map[string]bool{}
+				for _, tag := range *deployCmdTagSlice {
+					tagMap[tag] = true
+				}
+
+				for _, resource := range *resources {
+					for _, tag := range resource.Tags {
+						if _, ok := tagMap[tag]; ok {
+							resourcesToDeploy = append(resourcesToDeploy, resource)
+							continue
+						}
+					}
+				}
+
+					log.Debug("Deploying these resources: \n\t", strings.Join(args, "\n\t"), "\nFrom provided tags.")
+				} else {
+				log.Debug("Received no arguments for deployment. Deploying all resources.")
+				resourcesToDeploy = *resources
+			}
 		} else {
 			log.Debug("Deploying these resources: \n\t", strings.Join(args, "\n\t"), "\nIn the order given.")
 
+			// TODO: Lots of duplicated code; maybe a helper?
 			// Map the slice by name so they can be fetched in order.
 			resourcesMap := map[string]Resource{}
 			for _, resource := range *resources {

--- a/cmd/hope/deploy.go
+++ b/cmd/hope/deploy.go
@@ -65,8 +65,8 @@ var deployCmd = &cobra.Command{
 					}
 				}
 
-					log.Debug("Deploying these resources: \n\t", strings.Join(args, "\n\t"), "\nFrom provided tags.")
-				} else {
+				log.Debug("Deploying these resources: \n\t", strings.Join(args, "\n\t"), "\nFrom provided tags.")
+			} else {
 				log.Debug("Received no arguments for deployment. Deploying all resources.")
 				resourcesToDeploy = *resources
 			}

--- a/cmd/hope/root.go
+++ b/cmd/hope/root.go
@@ -50,6 +50,7 @@ func Execute() {
 	rootCmd.AddCommand(sshCmd)
 	rootCmd.AddCommand(tokenCmd)
 
+	initDeployCmdFlags()
 	initHostnameCmdFlags()
 	initKubeconfigCmdFlags()
 	initResetCmd()

--- a/cmd/hope/utils.go
+++ b/cmd/hope/utils.go
@@ -36,14 +36,6 @@ type ExecSpec struct {
 	Command  []string
 }
 
-// TODO: Allow jobs to define max retry parameters, or accept them on the
-//   command line.
-type Job struct {
-	Name       string
-	File       string
-	Parameters []string
-}
-
 type Resource struct {
 	Name       string
 	File       string
@@ -53,6 +45,14 @@ type Resource struct {
 	Job        string
 	Exec       ExecSpec
 	Tags       []string
+}
+
+// TODO: Allow jobs to define max retry parameters, or accept them on the
+//   command line.
+type Job struct {
+	Name       string
+	File       string
+	Parameters []string
 }
 
 func (resource *Resource) GetType() (string, error) {

--- a/cmd/hope/utils.go
+++ b/cmd/hope/utils.go
@@ -36,6 +36,14 @@ type ExecSpec struct {
 	Command  []string
 }
 
+// TODO: Allow jobs to define max retry parameters, or accept them on the
+//   command line.
+type Job struct {
+	Name       string
+	File       string
+	Parameters []string
+}
+
 type Resource struct {
 	Name       string
 	File       string
@@ -44,14 +52,7 @@ type Resource struct {
 	Build      BuildSpec
 	Job        string
 	Exec       ExecSpec
-}
-
-// TODO: Allow jobs to define max retry parameters, or accept them on the
-//   command line.
-type Job struct {
-	Name       string
-	File       string
-	Parameters []string
+	Tags       []string
 }
 
 func (resource *Resource) GetType() (string, error) {

--- a/hope.yaml
+++ b/hope.yaml
@@ -13,10 +13,14 @@ resources:
   # It will always be preferred that urls appearing here are to stable yaml
   #   files available on the Internet, rather than anything loaded from the
   #   local machine.
-  # Local paths can be used for testing, but ultimately, whatever ends up being
-  #   deployed should be done so using GitHub tags/releases.
+  # Local paths can be used for testing, but ultimately, whatever ends up
+  #   being deployed should be done so using GitHub tags/releases.
+  # Every resource can provide a set of tags that will allow for the
+  #   deployment of multiple resources without naming every resource
+  #   explicitly
   - name: calico
     file: https://docs.projectcalico.org/manifests/calico.yaml
+    tags: [network]
   # Inline definitions are also supported.
   # These values have to be provided as yaml strings under the `inline` key.
   # Values passed in through `inline` will be fed through `envsubst` before
@@ -52,6 +56,7 @@ resources:
         namespace: metallb-system
     parameters:
       - METALLB_SYSTEM_MEMBERLIST_SECRET_KEY
+    tags: [network]
   # Build and push a docker image to the registry.
   # Doesn't include a kubectl command at all, so that can be done in a step
   #   after a step like this appears.
@@ -64,6 +69,7 @@ resources:
     build:
       path: some-dir-with-dockerfile
       tag: registry.internal.aleemhaji.com/example-repo:latest
+    tags: [app1]
   # When a spec comes with an initialization procedure, a job type can be used.
   # These will wait until the job with the specified name is completed.
   # If the job fails, the deployment stops so that other resources that may
@@ -73,6 +79,7 @@ resources:
   #   set to be deleted by any mechanism.
   - name: wait-for-some-kind-of-job
     job: init-the-database
+    tags: [database]
   # If something needs to be executed against pods of an existing set of pods,
   #   the exec resource will run a script against a running instance.
   # A timeout can optionally be provided to wait for pods to start.
@@ -84,6 +91,7 @@ resources:
         - mysql
         - -e
         - select 1;
+    tags: [database]
 # Jobs contains a collection of specifications of templated jobs that can be
 #   run on demand in the cluster.
 # These jobs shouldn't be associated to the deployment of any particular

--- a/hope.yaml
+++ b/hope.yaml
@@ -17,7 +17,7 @@ resources:
   #   being deployed should be done so using GitHub tags/releases.
   # Every resource can provide a set of tags that will allow for the
   #   deployment of multiple resources without naming every resource
-  #   explicitly
+  #   explicitly.
   - name: calico
     file: https://docs.projectcalico.org/manifests/calico.yaml
     tags: [network]


### PR DESCRIPTION
Closes #23.

Introduces a `--tag` / `-t` flag that can be provided as many times as needed to deploy sets of resources with one string. 