### PR TITLE
Better parameter substitution logic

### DIFF
--- a/cmd/hope/deploy.go
+++ b/cmd/hope/deploy.go
@@ -14,7 +14,6 @@ import (
 
 import (
 	"github.com/Eagerod/hope/pkg/docker"
-	"github.com/Eagerod/hope/pkg/envsubst"
 	"github.com/Eagerod/hope/pkg/hope"
 	"github.com/Eagerod/hope/pkg/kubeutil"
 )
@@ -148,12 +147,14 @@ var deployCmd = &cobra.Command{
 
 				if len(resource.Parameters) != 0 {
 					log.Trace("Populating parameters: ", strings.Join(resource.Parameters, ", "))
-					inline, err = envsubst.GetEnvsubstArgsFromEnv(resource.Parameters, inline)
+					t := hope.NewTextSubstitutorFromString(inline)
+					err := t.SubstituteTextFromEnv(resource.Parameters)
 					if err != nil {
 						return err
 					}
+					inline = string(*t.Bytes)
 				} else {
-					log.Trace(resource.Name, " does not have any parameters. Skipping envsubst.")
+					log.Trace(resource.Name, " does not have any parameters. Skipping population.")
 				}
 
 				if err := hope.KubectlApplyStdIn(kubectl, inline); err != nil {

--- a/cmd/hope/deploy.go
+++ b/cmd/hope/deploy.go
@@ -145,7 +145,7 @@ var deployCmd = &cobra.Command{
 						return err
 					}
 				} else {
-					log.Trace(resource.Name, " does not have any parameters. Skipping envsubst and applying file directly")
+					log.Trace(resource.Name, " does not have any parameters. Skipping population and applying file directly")
 					if err := hope.KubectlApplyF(kubectl, resource.File); err != nil {
 						return err
 					}

--- a/cmd/hope/root.go
+++ b/cmd/hope/root.go
@@ -151,7 +151,7 @@ func patchInvocations() {
 	oldEnvsubstBytes := envsubst.GetEnvsubstBytes
 	envsubst.GetEnvsubstBytes = func(args []string, contents []byte) ([]byte, error) {
 		argsKeys := []string{}
-		for key, _ := range args {
+		for _, key := range args {
 			argsKeys = append(argsKeys, fmt.Sprintf("$%s", key))
 		}
 
@@ -162,7 +162,7 @@ func patchInvocations() {
 	oldEnvsubstBytesArgs := envsubst.GetEnvsubstBytesArgs
 	envsubst.GetEnvsubstBytesArgs = func(args map[string]string, contents []byte) ([]byte, error) {
 		argsKeys := []string{}
-		for _, key := range args {
+		for key, _ := range args {
 			argsKeys = append(argsKeys, fmt.Sprintf("$%s", key))
 		}
 

--- a/cmd/hope/root.go
+++ b/cmd/hope/root.go
@@ -148,26 +148,26 @@ func patchInvocations() {
 		return oldExecDocker(args...)
 	}
 
-	oldEnvSubstArgs := envsubst.GetEnvsubstArgs
-	envsubst.GetEnvsubstArgs = func(args map[string]string, str string) (string, error) {
+	oldEnvsubstBytes := envsubst.GetEnvsubstBytes
+	envsubst.GetEnvsubstBytes = func(args []string, contents []byte) ([]byte, error) {
 		argsKeys := []string{}
 		for key, _ := range args {
 			argsKeys = append(argsKeys, fmt.Sprintf("$%s", key))
 		}
 
-		log.Debug("echo **(", len(str), " chars)** | envsubst ", strings.Join(argsKeys, ","))
-		return oldEnvSubstArgs(args, str)
+		log.Debug("echo **(", len(contents), " chars)** | envsubst ", strings.Join(argsKeys, ","))
+		return oldEnvsubstBytes(args, contents)
 	}
 
-	oldEnvSubstArgsFromEnv := envsubst.GetEnvsubstArgsFromEnv
-	envsubst.GetEnvsubstArgsFromEnv = func(args []string, str string) (string, error) {
+	oldEnvsubstBytesArgs := envsubst.GetEnvsubstBytesArgs
+	envsubst.GetEnvsubstBytesArgs = func(args map[string]string, contents []byte) ([]byte, error) {
 		argsKeys := []string{}
 		for _, key := range args {
 			argsKeys = append(argsKeys, fmt.Sprintf("$%s", key))
 		}
 
-		log.Debug("echo **(", len(str), " chars)** | envsubst ", strings.Join(argsKeys, ","))
-		return oldEnvSubstArgsFromEnv(args, str)
+		log.Debug("echo **(", len(contents), " chars)** | envsubst ", strings.Join(argsKeys, ","))
+		return oldEnvsubstBytesArgs(args, contents)
 	}
 
 	oldExecKubectl := kubeutil.ExecKubectl

--- a/cmd/hope/root.go
+++ b/cmd/hope/root.go
@@ -148,12 +148,6 @@ func patchInvocations() {
 		return oldExecDocker(args...)
 	}
 
-	oldEnvSubst := envsubst.GetEnvsubst
-	envsubst.GetEnvsubst = func(str string) (string, error) {
-		log.Debug("echo **(", len(str), " chars)** | envsubst")
-		return oldEnvSubst(str)
-	}
-
 	oldEnvSubstArgs := envsubst.GetEnvsubstArgs
 	envsubst.GetEnvsubstArgs = func(args map[string]string, str string) (string, error) {
 		argsKeys := []string{}

--- a/cmd/hope/run.go
+++ b/cmd/hope/run.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"errors"
 	"fmt"
 	"regexp"
@@ -15,7 +14,6 @@ import (
 )
 
 import (
-	"github.com/Eagerod/hope/pkg/envsubst"
 	"github.com/Eagerod/hope/pkg/hope"
 )
 
@@ -77,16 +75,16 @@ var runCmd = &cobra.Command{
 		defer kubectl.Destroy()
 
 		// TODO: Move to pkg
-		jobContents, err := ioutil.ReadFile(job.File)
+		t, err := hope.TextSubstitutorFromFilepath(job.File)
 		if err != nil {
 			return err
 		}
 
-		jobText, err := envsubst.GetEnvsubstArgs(params, string(jobContents))
-		if err != nil {
+		if err := t.SubstituteTextFromMap(params); err != nil {
 			return err
 		}
 
+		jobText := string(*t.Bytes)
 		output, err := hope.KubectlGetCreateStdIn(kubectl, jobText)
 		if err != nil {
 			return err

--- a/cmd/hope/run.go
+++ b/cmd/hope/run.go
@@ -55,7 +55,7 @@ var runCmd = &cobra.Command{
 			remainingParams[paramName] = false
 			fullArgsList = append(fullArgsList, param)
 		}
-		
+
 		for param, missed := range remainingParams {
 			if missed {
 				fullArgsList = append(fullArgsList, param)

--- a/cmd/hope/run.go
+++ b/cmd/hope/run.go
@@ -37,6 +37,9 @@ var runCmd = &cobra.Command{
 
 		// Combine args given from the command line, and ones not given to let
 		//   the parameter substitution fall back to env when available.
+		// Would probably be faster to just populate from the slice, then from
+		//   any remaining args via env, but this adds some extra validation
+		//   that would otherwise go unchecked.
 		fullArgsList := []string{}
 
 		remainingParams := map[string]bool{}

--- a/cmd/hope/utils.go
+++ b/cmd/hope/utils.go
@@ -117,3 +117,40 @@ func getJob(jobName string) (*Job, error) {
 	}
 	return nil, errors.New(fmt.Sprintf("Failed to find a job named %s", jobName))
 }
+
+func replaceParametersInString(str string, parameters []string) (string, error) {
+	t := hope.NewTextSubstitutorFromString(str)
+	return replaceParametersWithSubstitutor(t, parameters)
+}
+
+func replaceParametersInFile(path string, parameters []string) (string, error) {
+	t, err := hope.TextSubstitutorFromFilepath(path)
+	if err != nil {
+		return "", err
+	}
+
+	return replaceParametersWithSubstitutor(t, parameters)
+}
+
+func replaceParametersWithSubstitutor(t *hope.TextSubstitutor, parameters []string) (string, error) {
+	envParams := []string{}
+	directParams := map[string]string{}
+	for _, value := range parameters {
+		parts := strings.SplitN(value, "=", 2)
+		if len(parts) == 1 {
+			envParams = append(envParams, value)
+		} else {
+			directParams[parts[0]] = parts[1]
+		}
+	}
+
+	if err := t.SubstituteTextFromEnv(envParams); err != nil {
+		return "", err
+	}
+
+	if err := t.SubstituteTextFromMap(directParams); err != nil {
+		return "", err
+	}
+
+	return string(*t.Bytes), nil
+}

--- a/cmd/hope/utils_test.go
+++ b/cmd/hope/utils_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplaceParametersInString(t *testing.T) {
+	os.Setenv("HELLO", "Hello,")
+	os.Setenv("WORLD", "World!")
+
+	var tests = []struct {
+		name       string
+		in         string
+		out        string
+		parameters []string
+	}{
+		{"All Envs", "${HELLO} $WORLD", "Hello, World!", []string{"HELLO", "WORLD"}},
+		{"One Env", "${HELLO} $WORLD", "Hello, Moon!", []string{"HELLO", "WORLD=Moon!"}},
+		{"No Envs", "${HELLO} $WORLD", "${HELLO} $WORLD", []string{}},
+		{"Var with =", "${HELLO} $WORLD", "e30= $WORLD", []string{"HELLO=e30="}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := replaceParametersInString(tt.in, tt.parameters)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.out, s)
+		})
+	}
+
+	os.Unsetenv("HELLO")
+	os.Unsetenv("WORLD")
+}

--- a/pkg/envsubst/envsubst.go
+++ b/pkg/envsubst/envsubst.go
@@ -1,6 +1,7 @@
 package envsubst
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -10,6 +11,8 @@ import (
 
 type GetEnvsubstStringFunc func(str string) (string, error)
 type GetEnvsubstStringArgsFunc func(args map[string]string, str string) (string, error)
+type GetEnvsubstBytesArgsFunc func(args map[string]string, bytes []byte) ([]byte, error)
+type GetEnvsubstBytesArgsFromEnvFunc func(args []string, bytes []byte) ([]byte, error)
 type GetEnvsubstStringArgsFromEnvFunc func(args []string, str string) (string, error)
 
 var GetEnvsubst GetEnvsubstStringFunc = func(str string) (string, error) {
@@ -21,7 +24,29 @@ var GetEnvsubst GetEnvsubstStringFunc = func(str string) (string, error) {
 	return string(outputBytes), err
 }
 
-var GetEnvsubstArgs GetEnvsubstStringArgsFunc = func(args map[string]string, str string) (string, error) {
+var GetEnvsubstBytes GetEnvsubstBytesArgsFromEnvFunc = func(args []string, contents []byte) ([]byte, error) {
+	if len(args) == 0 {
+		return contents, nil
+	}
+
+	// If any argument isn't given, return an error
+	argsKeys := []string{}
+	for _, key := range args {
+		_, exists := os.LookupEnv(key)
+		if !exists {
+			return []byte{}, errors.New(fmt.Sprintf("Failed to find %s in environment.", key))
+		}
+		argsKeys = append(argsKeys, fmt.Sprintf("$%s", key))
+	}
+
+	osCmd := exec.Command("envsubst", strings.Join(argsKeys, ","))
+	osCmd.Stdin = bytes.NewReader(contents)
+	osCmd.Stderr = os.Stderr
+
+	return osCmd.Output()
+}
+
+var GetEnvsubstBytesArgs GetEnvsubstBytesArgsFunc = func(args map[string]string, contents []byte) ([]byte, error) {
 	argsKeys := []string{}
 	for key, _ := range args {
 		argsKeys = append(argsKeys, fmt.Sprintf("$%s", key))
@@ -34,32 +59,27 @@ var GetEnvsubstArgs GetEnvsubstStringArgsFunc = func(args map[string]string, str
 		osCmd.Env = append(osCmd.Env, fmt.Sprintf("%s=%s", key, value))
 	}
 
-	osCmd.Stdin = strings.NewReader(str)
+	osCmd.Stdin = bytes.NewReader(contents)
 	osCmd.Stderr = os.Stderr
 
-	outputBytes, err := osCmd.Output()
-	return string(outputBytes), err
+	return osCmd.Output()
+}
+
+
+var GetEnvsubstArgs GetEnvsubstStringArgsFunc = func(args map[string]string, str string) (string, error) {
+	outputBytes, err := GetEnvsubstBytesArgs(args, []byte(str))
+	if err != nil {
+		return "", err
+	}
+
+	return string(outputBytes), nil
 }
 
 var GetEnvsubstArgsFromEnv GetEnvsubstStringArgsFromEnvFunc = func(args []string, str string) (string, error) {
-	if len(args) == 0 {
-		return str, nil
+	outputBytes, err := GetEnvsubstBytes(args, []byte(str))
+	if err != nil {
+		return "", err
 	}
 
-	// If any argument isn't given, return an error
-	argsKeys := []string{}
-	for _, key := range args {
-		_, exists := os.LookupEnv(key)
-		if !exists {
-			return "", errors.New(fmt.Sprintf("Failed to find %s in environment.", key))
-		}
-		argsKeys = append(argsKeys, fmt.Sprintf("$%s", key))
-	}
-
-	osCmd := exec.Command("envsubst", strings.Join(argsKeys, ","))
-	osCmd.Stdin = strings.NewReader(str)
-	osCmd.Stderr = os.Stderr
-
-	outputBytes, err := osCmd.Output()
-	return string(outputBytes), err
+	return string(outputBytes), nil
 }

--- a/pkg/envsubst/envsubst.go
+++ b/pkg/envsubst/envsubst.go
@@ -9,20 +9,11 @@ import (
 	"strings"
 )
 
-type GetEnvsubstStringFunc func(str string) (string, error)
 type GetEnvsubstStringArgsFunc func(args map[string]string, str string) (string, error)
 type GetEnvsubstBytesArgsFunc func(args map[string]string, bytes []byte) ([]byte, error)
 type GetEnvsubstBytesArgsFromEnvFunc func(args []string, bytes []byte) ([]byte, error)
 type GetEnvsubstStringArgsFromEnvFunc func(args []string, str string) (string, error)
 
-var GetEnvsubst GetEnvsubstStringFunc = func(str string) (string, error) {
-	osCmd := exec.Command("envsubst")
-	osCmd.Stdin = strings.NewReader(str)
-	osCmd.Stderr = os.Stderr
-
-	outputBytes, err := osCmd.Output()
-	return string(outputBytes), err
-}
 
 var GetEnvsubstBytes GetEnvsubstBytesArgsFromEnvFunc = func(args []string, contents []byte) ([]byte, error) {
 	if len(args) == 0 {

--- a/pkg/envsubst/envsubst.go
+++ b/pkg/envsubst/envsubst.go
@@ -12,7 +12,6 @@ import (
 type GetEnvsubstBytesArgsFunc func(args map[string]string, bytes []byte) ([]byte, error)
 type GetEnvsubstBytesArgsFromEnvFunc func(args []string, bytes []byte) ([]byte, error)
 
-
 var GetEnvsubstBytes GetEnvsubstBytesArgsFromEnvFunc = func(args []string, contents []byte) ([]byte, error) {
 	if len(args) == 0 {
 		return contents, nil
@@ -53,7 +52,6 @@ var GetEnvsubstBytesArgs GetEnvsubstBytesArgsFunc = func(args map[string]string,
 
 	return osCmd.Output()
 }
-
 
 func GetEnvsubstArgs(args map[string]string, str string) (string, error) {
 	outputBytes, err := GetEnvsubstBytesArgs(args, []byte(str))

--- a/pkg/envsubst/envsubst.go
+++ b/pkg/envsubst/envsubst.go
@@ -52,21 +52,3 @@ var GetEnvsubstBytesArgs GetEnvsubstBytesArgsFunc = func(args map[string]string,
 
 	return osCmd.Output()
 }
-
-func GetEnvsubstArgs(args map[string]string, str string) (string, error) {
-	outputBytes, err := GetEnvsubstBytesArgs(args, []byte(str))
-	if err != nil {
-		return "", err
-	}
-
-	return string(outputBytes), nil
-}
-
-func GetEnvsubstArgsFromEnv(args []string, str string) (string, error) {
-	outputBytes, err := GetEnvsubstBytes(args, []byte(str))
-	if err != nil {
-		return "", err
-	}
-
-	return string(outputBytes), nil
-}

--- a/pkg/envsubst/envsubst.go
+++ b/pkg/envsubst/envsubst.go
@@ -9,10 +9,8 @@ import (
 	"strings"
 )
 
-type GetEnvsubstStringArgsFunc func(args map[string]string, str string) (string, error)
 type GetEnvsubstBytesArgsFunc func(args map[string]string, bytes []byte) ([]byte, error)
 type GetEnvsubstBytesArgsFromEnvFunc func(args []string, bytes []byte) ([]byte, error)
-type GetEnvsubstStringArgsFromEnvFunc func(args []string, str string) (string, error)
 
 
 var GetEnvsubstBytes GetEnvsubstBytesArgsFromEnvFunc = func(args []string, contents []byte) ([]byte, error) {
@@ -57,7 +55,7 @@ var GetEnvsubstBytesArgs GetEnvsubstBytesArgsFunc = func(args map[string]string,
 }
 
 
-var GetEnvsubstArgs GetEnvsubstStringArgsFunc = func(args map[string]string, str string) (string, error) {
+func GetEnvsubstArgs(args map[string]string, str string) (string, error) {
 	outputBytes, err := GetEnvsubstBytesArgs(args, []byte(str))
 	if err != nil {
 		return "", err
@@ -66,7 +64,7 @@ var GetEnvsubstArgs GetEnvsubstStringArgsFunc = func(args map[string]string, str
 	return string(outputBytes), nil
 }
 
-var GetEnvsubstArgsFromEnv GetEnvsubstStringArgsFromEnvFunc = func(args []string, str string) (string, error) {
+func GetEnvsubstArgsFromEnv(args []string, str string) (string, error) {
 	outputBytes, err := GetEnvsubstBytes(args, []byte(str))
 	if err != nil {
 		return "", err

--- a/pkg/hope/text_substitutor.go
+++ b/pkg/hope/text_substitutor.go
@@ -1,0 +1,51 @@
+package hope
+
+import (
+	"io/ioutil"
+)
+
+import (
+	"github.com/Eagerod/hope/pkg/envsubst"
+)
+
+type TextSubstitutor struct {
+	Bytes *[]byte
+}
+
+func NewTextSubstitutorFromBytes(bytes []byte) *TextSubstitutor {
+	t := TextSubstitutor{&bytes}
+	return &t
+}
+
+func NewTextSubstitutorFromString(str string) *TextSubstitutor {
+	return NewTextSubstitutorFromBytes([]byte(str))
+}
+
+func TextSubstitutorFromFilepath(filepath string) (*TextSubstitutor, error) {
+	fileContents, err := ioutil.ReadFile(filepath)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTextSubstitutorFromBytes(fileContents), nil
+}
+
+func (t *TextSubstitutor) SubstituteTextFromEnv(envVarsNames []string) error {
+	newBytes, err := envsubst.GetEnvsubstBytes(envVarsNames, *t.Bytes)
+	if err != nil {
+		return err
+	}
+
+	t.Bytes = &newBytes
+	return nil
+}
+
+func (t *TextSubstitutor) SubstituteTextFromMap(variables map[string]string) error {
+	newBytes, err := envsubst.GetEnvsubstBytesArgs(variables, *t.Bytes)
+	if err != nil {
+		return err
+	}
+
+	t.Bytes = &newBytes
+	return nil
+}

--- a/pkg/hope/text_substitutor.go
+++ b/pkg/hope/text_substitutor.go
@@ -31,6 +31,12 @@ func TextSubstitutorFromFilepath(filepath string) (*TextSubstitutor, error) {
 }
 
 func (t *TextSubstitutor) SubstituteTextFromEnv(envVarsNames []string) error {
+	// Don't even hit the downstream tool if we aren't trying to populate
+	//   anything.
+	if len(envVarsNames) == 0 {
+		return nil
+	}
+
 	newBytes, err := envsubst.GetEnvsubstBytes(envVarsNames, *t.Bytes)
 	if err != nil {
 		return err
@@ -41,6 +47,12 @@ func (t *TextSubstitutor) SubstituteTextFromEnv(envVarsNames []string) error {
 }
 
 func (t *TextSubstitutor) SubstituteTextFromMap(variables map[string]string) error {
+	// Don't even hit the downstream tool if we aren't trying to populate
+	//   anything.
+	if len(variables) == 0 {
+		return nil
+	}
+
 	newBytes, err := envsubst.GetEnvsubstBytesArgs(variables, *t.Bytes)
 	if err != nil {
 		return err

--- a/pkg/hope/text_substitutor_test.go
+++ b/pkg/hope/text_substitutor_test.go
@@ -1,0 +1,65 @@
+package hope
+
+import (
+	"os"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubstituteTextFromEnv(t *testing.T) {
+	os.Setenv("HELLO", "Hello,")
+	os.Setenv("WORLD", "World!")
+
+	var tests = []struct {
+		name string
+		in  string
+		out  string
+		vars  []string
+	}{
+		{"All Envs", "${HELLO} $WORLD", "Hello, World!", []string{"HELLO", "WORLD"}},
+		{"One Env", "${HELLO} $WORLD", "Hello, $WORLD", []string{"HELLO"}},
+		{"No Envs", "${HELLO} $WORLD", "${HELLO} $WORLD", []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := NewTextSubstitutorFromString(tt.in)
+			err := ts.SubstituteTextFromEnv(tt.vars)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.out, string(*ts.Bytes))
+		})
+	}
+
+	os.Unsetenv("HELLO")
+	os.Unsetenv("WORLD")
+}
+
+func TestSubstituteTextFromVars(t *testing.T) {
+	// Set the envs to make sure they aren't being pulled from there.
+	os.Setenv("HELLO", "Goodnight,")
+	os.Setenv("WORLD", "Moon!")
+
+	var tests = []struct {
+		name string
+		in  string
+		out  string
+		vars  map[string]string
+	}{
+		{"All Envs", "${HELLO} $WORLD", "Hello, World!", map[string]string{"HELLO": "Hello,", "WORLD": "World!"}},
+		{"One Env", "${HELLO} $WORLD", "Hello, $WORLD", map[string]string{"HELLO": "Hello,"}},
+		{"No Envs", "${HELLO} $WORLD", "${HELLO} $WORLD", map[string]string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := NewTextSubstitutorFromString(tt.in)
+			err := ts.SubstituteTextFromMap(tt.vars)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.out, string(*ts.Bytes))
+		})
+	}
+
+	os.Unsetenv("HELLO")
+	os.Unsetenv("WORLD")
+}

--- a/pkg/hope/text_substitutor_test.go
+++ b/pkg/hope/text_substitutor_test.go
@@ -36,6 +36,14 @@ func TestSubstituteTextFromEnv(t *testing.T) {
 	os.Unsetenv("WORLD")
 }
 
+func TestSubstituteTextFromEnvMissingEnv(t *testing.T) {
+	//Slightly over-reaching test, since the text sub isn't responsible for
+	//   this error message.
+	ts := NewTextSubstitutorFromString("${HELLO} $WORLD")
+	err := ts.SubstituteTextFromEnv([]string{"HELLO"})
+	assert.Equal(t, err.Error(), "Failed to find HELLO in environment.")
+}
+
 func TestSubstituteTextFromVars(t *testing.T) {
 	// Set the envs to make sure they aren't being pulled from there.
 	os.Setenv("HELLO", "Goodnight,")

--- a/pkg/hope/text_substitutor_test.go
+++ b/pkg/hope/text_substitutor_test.go
@@ -15,9 +15,9 @@ func TestSubstituteTextFromEnv(t *testing.T) {
 
 	var tests = []struct {
 		name string
-		in  string
+		in   string
 		out  string
-		vars  []string
+		vars []string
 	}{
 		{"All Envs", "${HELLO} $WORLD", "Hello, World!", []string{"HELLO", "WORLD"}},
 		{"One Env", "${HELLO} $WORLD", "Hello, $WORLD", []string{"HELLO"}},
@@ -51,9 +51,9 @@ func TestSubstituteTextFromVars(t *testing.T) {
 
 	var tests = []struct {
 		name string
-		in  string
+		in   string
 		out  string
-		vars  map[string]string
+		vars map[string]string
 	}{
 		{"All Envs", "${HELLO} $WORLD", "Hello, World!", map[string]string{"HELLO": "Hello,", "WORLD": "World!"}},
 		{"One Env", "${HELLO} $WORLD", "Hello, $WORLD", map[string]string{"HELLO": "Hello,"}},


### PR DESCRIPTION
Consolidates any kind of parameter substitution to use a common interface. 

- Direct-file deploys are now allowed to ask for parameters to be substituted.
- File and inline deploys can now define default values for arguments if not given via environment.
- Job runs now fall back to the environment in cases where an `=` isn't present in the provided value.

Introduces a struct to keep track of it all, and so tests can be defined against its interface. 