### PR TITLE
Nest node commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,9 @@ PACKAGE_PATHS := $(CMD_PACKAGE_DIR) $(PKG_PACKAGE_DIR)
 
 AUTOGEN_VERSION_FILENAME=$(CMD_PACKAGE_DIR)/version-temp.go
 
+ALL_GO_DIRS = $(shell find . -iname "*.go" -exec dirname {} \; | sort | uniq)
 SRC := $(shell find . -iname "*.go" -and -not -name "*_test.go") $(AUTOGEN_VERSION_FILENAME)
-PUBLISH := publish/linux-amd64 publish/darwin-amd64
+PUBLISH = publish/linux-amd64 publish/darwin-amd64
 
 .PHONY: all
 all: $(BIN_NAME)
@@ -87,9 +88,7 @@ pretty-coverage: test-cover
 
 .PHONY: fmt
 fmt:
-	@$(GO) fmt .
-	@$(GO) fmt $(CMD_PACKAGE_DIR)
-	@$(GO) fmt $(PKG_PACKAGE_DIR)
+	@$(GO) fmt $(ALL_GO_DIRS)
 
 .PHONY: clean
 clean:

--- a/cmd/hope/deploy.go
+++ b/cmd/hope/deploy.go
@@ -81,7 +81,7 @@ var deployCmd = &cobra.Command{
 		//   above; if there isn't anything that needs to talk to kubernetes,
 		//   don't even bother pulling the kubeconfig.
 		masters := viper.GetStringSlice("masters")
-		kubectl, err := getKubectlFromAnyMaster(log.WithFields(log.Fields{}), masters)
+		kubectl, err := kubeutil.NewKubectlFromAnyNode(masters)
 		if err != nil {
 			return err
 		}

--- a/cmd/hope/node/hostname.go
+++ b/cmd/hope/node/hostname.go
@@ -1,4 +1,4 @@
-package cmd
+package node
 
 import (
 	"errors"

--- a/cmd/hope/node/init.go
+++ b/cmd/hope/node/init.go
@@ -1,4 +1,4 @@
-package cmd
+package node
 
 import (
 	"errors"
@@ -14,6 +14,7 @@ import (
 
 import (
 	"github.com/Eagerod/hope/pkg/hope"
+	"github.com/Eagerod/hope/pkg/kubeutil"
 	"github.com/Eagerod/hope/pkg/sliceutil"
 )
 
@@ -47,7 +48,7 @@ var initCmd = &cobra.Command{
 				return err
 			}
 
-			kubectl, err := getKubectlFromAnyMaster(log.WithFields(log.Fields{}), masters)
+			kubectl, err := kubeutil.NewKubectlFromAnyNode(masters)
 			if err != nil {
 				return err
 			}

--- a/cmd/hope/node/reset.go
+++ b/cmd/hope/node/reset.go
@@ -1,4 +1,4 @@
-package cmd
+package node
 
 import (
 	"errors"
@@ -13,6 +13,7 @@ import (
 
 import (
 	"github.com/Eagerod/hope/pkg/hope"
+	"github.com/Eagerod/hope/pkg/kubeutil"
 	"github.com/Eagerod/hope/pkg/sliceutil"
 )
 
@@ -39,7 +40,7 @@ var resetCmd = &cobra.Command{
 
 		// If force is set, failing to find a kubeconfig shouldn't stop the
 		//   command from brute force reseting the node.
-		kubectl, err := getKubectlFromAnyMaster(log.WithFields(log.Fields{}), masters)
+		kubectl, err := kubeutil.NewKubectlFromAnyNode(masters)
 		if err != nil {
 			if !resetCmdForce {
 				return err

--- a/cmd/hope/node/root.go
+++ b/cmd/hope/node/root.go
@@ -1,0 +1,22 @@
+package node
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var RootCommand = &cobra.Command{
+	Use:   "node",
+	Short: "command line tool for managing nodes on the network",
+	Long: "Manage ESXi vms",
+}
+
+func InitNodeCommand() {
+	RootCommand.AddCommand(hostnameCmd)
+	RootCommand.AddCommand(initCmd)
+	RootCommand.AddCommand(resetCmd)
+	RootCommand.AddCommand(sshCmd)
+
+	initHostnameCmdFlags()
+	initResetCmd()
+	initSshCmd()
+}

--- a/cmd/hope/node/root.go
+++ b/cmd/hope/node/root.go
@@ -7,7 +7,7 @@ import (
 var RootCommand = &cobra.Command{
 	Use:   "node",
 	Short: "manage nodes on the network",
-	Long: "Manage adding, removing, modifying nodes in the cluster",
+	Long:  "Manage adding, removing, modifying nodes in the cluster",
 }
 
 func InitNodeCommand() {

--- a/cmd/hope/node/root.go
+++ b/cmd/hope/node/root.go
@@ -6,8 +6,8 @@ import (
 
 var RootCommand = &cobra.Command{
 	Use:   "node",
-	Short: "command line tool for managing nodes on the network",
-	Long: "Manage ESXi vms",
+	Short: "manage nodes on the network",
+	Long: "Manage adding, removing, modifying nodes in the cluster",
 }
 
 func InitNodeCommand() {

--- a/cmd/hope/node/ssh.go
+++ b/cmd/hope/node/ssh.go
@@ -1,4 +1,4 @@
-package cmd
+package node
 
 import (
 	"errors"

--- a/cmd/hope/remove.go
+++ b/cmd/hope/remove.go
@@ -13,6 +13,7 @@ import (
 
 import (
 	"github.com/Eagerod/hope/pkg/hope"
+	"github.com/Eagerod/hope/pkg/kubeutil"
 )
 
 var removeCmdTagSlice *[]string
@@ -43,7 +44,7 @@ var removeCmd = &cobra.Command{
 		// Wait as long as possible before pulling the temporary kubectl from
 		//   a master node.
 		masters := viper.GetStringSlice("masters")
-		kubectl, err := getKubectlFromAnyMaster(log.WithFields(log.Fields{}), masters)
+		kubectl, err := kubeutil.NewKubectlFromAnyNode(masters)
 		if err != nil {
 			return err
 		}

--- a/cmd/hope/root.go
+++ b/cmd/hope/root.go
@@ -14,6 +14,7 @@ import (
 )
 
 import (
+	"github.com/Eagerod/hope/cmd/hope/node"
 	"github.com/Eagerod/hope/cmd/hope/unifi"
 
 	"github.com/Eagerod/hope/pkg/docker"
@@ -41,32 +42,27 @@ Kubernetes resources I run.`,
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(deployCmd)
 	rootCmd.AddCommand(versionCmd)
-	rootCmd.AddCommand(hostnameCmd)
 	rootCmd.AddCommand(kubeconfigCmd)
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(removeCmd)
-	rootCmd.AddCommand(resetCmd)
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(shellCmd)
-	rootCmd.AddCommand(sshCmd)
 	rootCmd.AddCommand(tokenCmd)
 
+	rootCmd.AddCommand(node.RootCommand)
 	rootCmd.AddCommand(unifi.RootCommand)
 
 	initDeployCmdFlags()
-	initHostnameCmdFlags()
 	initKubeconfigCmdFlags()
 	initListCmdFlags()
 	initRemoveCmdFlags()
-	initResetCmd()
 	initRunCmdFlags()
 	initShellCmd()
-	initSshCmd()
 	initTokenCmd()
 
+	node.InitNodeCommand()
 	unifi.InitUnifiCommand()
 
 	log.Debug("Executing:", os.Args)

--- a/cmd/hope/run.go
+++ b/cmd/hope/run.go
@@ -15,6 +15,7 @@ import (
 
 import (
 	"github.com/Eagerod/hope/pkg/hope"
+	"github.com/Eagerod/hope/pkg/kubeutil"
 )
 
 var runCmdParameterSlice *[]string
@@ -74,7 +75,7 @@ var runCmd = &cobra.Command{
 		// Pull kubeconfig from remote as late as possible to avoid extra
 		//   network time before validation is done.
 		masters := viper.GetStringSlice("masters")
-		kubectl, err := getKubectlFromAnyMaster(log.WithFields(log.Fields{}), masters)
+		kubectl, err := kubeutil.NewKubectlFromAnyNode(masters)
 		if err != nil {
 			return err
 		}

--- a/cmd/hope/shell.go
+++ b/cmd/hope/shell.go
@@ -6,7 +6,6 @@ import (
 )
 
 import (
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -31,7 +30,7 @@ var shellCmd = &cobra.Command{
 		}
 
 		masters := viper.GetStringSlice("masters")
-		kubectl, err := getKubectlFromAnyMaster(log.WithFields(log.Fields{}), masters)
+		kubectl, err := kubeutil.NewKubectlFromAnyNode(masters)
 		if err != nil {
 			return err
 		}

--- a/cmd/hope/token.go
+++ b/cmd/hope/token.go
@@ -6,7 +6,6 @@ import (
 )
 
 import (
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -29,7 +28,7 @@ var tokenCmd = &cobra.Command{
 		username := args[0]
 		masters := viper.GetStringSlice("masters")
 
-		kubectl, err := getKubectlFromAnyMaster(log.WithFields(log.Fields{}), masters)
+		kubectl, err := kubeutil.NewKubectlFromAnyNode(masters)
 		if err != nil {
 			return err
 		}

--- a/cmd/hope/unifi/root.go
+++ b/cmd/hope/unifi/root.go
@@ -7,7 +7,7 @@ import (
 var RootCommand = &cobra.Command{
 	Use:   "unifi",
 	Short: "command line tool for managing UniFi resources",
-	Long: "Manage UniFi software configurations without manually operating against the resources",
+	Long:  "Manage UniFi software configurations without manually operating against the resources",
 }
 
 func InitUnifiCommand() {

--- a/cmd/hope/unifi/root.go
+++ b/cmd/hope/unifi/root.go
@@ -7,7 +7,7 @@ import (
 var RootCommand = &cobra.Command{
 	Use:   "unifi",
 	Short: "command line tool for managing UniFi resources",
-	Long: `Manage UniFi software configurations without manually operating against the resources`,
+	Long: "Manage UniFi software configurations without manually operating against the resources",
 }
 
 func InitUnifiCommand() {

--- a/cmd/hope/utils.go
+++ b/cmd/hope/utils.go
@@ -7,13 +7,11 @@ import (
 )
 
 import (
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
 import (
 	"github.com/Eagerod/hope/pkg/hope"
-	"github.com/Eagerod/hope/pkg/kubeutil"
 	"github.com/Eagerod/hope/pkg/maputil"
 )
 
@@ -82,20 +80,6 @@ func (resource *Resource) GetType() (string, error) {
 	default:
 		return "", errors.New(fmt.Sprintf("Detected multiple types for resource '%s': %s", resource.Name, strings.Join(detectedTypes, ", ")))
 	}
-}
-
-// Loops through the list of hosts in order, and attempts to fetch a
-//   kubeconfig file that will allow access to the cluster.
-func getKubectlFromAnyMaster(log *logrus.Entry, masters []string) (*kubeutil.Kubectl, error) {
-	for _, host := range masters {
-		log.Debug("Trying to fetch kubeconfig from host ", host, " from masters list")
-		kubectl, err := hope.GetKubectl(host)
-		if err == nil {
-			return kubectl, nil
-		}
-	}
-
-	return nil, errors.New("Failed to find a kubeconfig file on any host")
 }
 
 func getResources() (*[]Resource, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -11,24 +11,36 @@ import (
 )
 
 var bin string = filepath.Join(".", "build", "hope")
-var commands []string = []string{
-	"deploy",
-	"hostname",
-	"init",
-	"reset",
-	"version",
-}
 
 func TestHelpExecutes(t *testing.T) {
-	cmd := exec.Command(bin, "--help")
+	var tests = []struct {
+		name string
+		args []string
+	}{
+		{"Base Command", []string{}},
+		{"Node Base Command", []string{"node"}},
+		{"Node Hostname", []string{"node", "hostname"}},
+		{"Node Init", []string{"node", "init"}},
+		{"Node Reset", []string{"node", "reset"}},
+		{"Node SSH", []string{"node", "ssh"}},
+		{"Unifi Base Command", []string{"unifi"}},
+		{"Unifi Access Point", []string{"unifi", "ap"}},
+		{"Deploy", []string{"deploy"}},
+		{"Kubeconfig", []string{"kubeconfig"}},
+		{"List", []string{"list"}},
+		{"Remove", []string{"remove"}},
+		{"Run", []string{"run"}},
+		{"Shell", []string{"shell"}},
+		{"Token", []string{"token"}},
+		{"Version", []string{"version"}},
+	}
 
-	_, err := cmd.CombinedOutput()
-	assert.NoError(t, err)
-
-	for _, command := range commands {
-		cmd = exec.Command(bin, command, "--help")
-
-		_, err = cmd.CombinedOutput()
-		assert.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allArgs := append(tt.args, "--help")
+			cmd := exec.Command(bin, allArgs...)
+			_, err := cmd.CombinedOutput()
+			assert.NoError(t, err)
+		})
 	}
 }

--- a/pkg/hope/remote_kubeconfig.go
+++ b/pkg/hope/remote_kubeconfig.go
@@ -17,29 +17,6 @@ import (
 	"github.com/Eagerod/hope/pkg/scp"
 )
 
-func GetKubectl(host string) (*kubeutil.Kubectl, error) {
-	remoteFile := fmt.Sprintf("%s:/etc/kubernetes/admin.conf", host)
-
-	// Do not delete.
-	// Leave deletion up to destroying the kubectl instance.
-	tempFile, err := ioutil.TempFile("", "")
-	if err != nil {
-		return nil, err
-	}
-
-	// Close the file immediately, because it will be written by a subprocess.
-	if err := tempFile.Close(); err != nil {
-		return nil, err
-	}
-
-	if err = scp.ExecSCP(remoteFile, tempFile.Name()); err != nil {
-		return nil, err
-	}
-
-	kubectl := kubeutil.NewKubectl(tempFile.Name())
-	return kubectl, nil
-}
-
 func FetchKubeconfig(log *logrus.Entry, host string, merge bool) error {
 	kubeconfigFile, err := kubeutil.GetKubeConfigPath()
 	if err != nil {

--- a/pkg/hope/remote_kubeconfig.go
+++ b/pkg/hope/remote_kubeconfig.go
@@ -2,7 +2,6 @@ package hope
 
 import (
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 )
@@ -14,7 +13,6 @@ import (
 import (
 	"github.com/Eagerod/hope/pkg/fileutil"
 	"github.com/Eagerod/hope/pkg/kubeutil"
-	"github.com/Eagerod/hope/pkg/scp"
 )
 
 func FetchKubeconfig(log *logrus.Entry, host string, merge bool) error {
@@ -23,7 +21,7 @@ func FetchKubeconfig(log *logrus.Entry, host string, merge bool) error {
 		return err
 	}
 
-	kubectl, err := GetKubectl(host)
+	kubectl, err := kubeutil.NewKubectlFromNode(host)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubeutil/kubectl.go
+++ b/pkg/kubeutil/kubectl.go
@@ -23,10 +23,6 @@ func NewKubectl(kubeconfigPath string) *Kubectl {
 	return &Kubectl{kubeconfigPath}
 }
 
-func (kubectl *Kubectl) Destroy() error {
-	return os.Remove(kubectl.KubeconfigPath)
-}
-
 func NewKubectlFromNode(host string) (*Kubectl, error) {
 	remoteFile := fmt.Sprintf("%s:/etc/kubernetes/admin.conf", host)
 
@@ -63,4 +59,8 @@ func NewKubectlFromAnyNode(hosts []string) (*Kubectl, error) {
 	}
 
 	return nil, errors.New("Failed to find a kubeconfig file on any host:\n" + allErrorsStr)
+}
+
+func (kubectl *Kubectl) Destroy() error {
+	return os.Remove(kubectl.KubeconfigPath)
 }

--- a/pkg/kubeutil/kubectl.go
+++ b/pkg/kubeutil/kubectl.go
@@ -1,7 +1,14 @@
 package kubeutil
 
 import (
+	"errors"
+	"fmt"
+	"io/ioutil"
 	"os"
+)
+
+import (
+	"github.com/Eagerod/hope/pkg/scp"
 )
 
 // Kubectl struct allows for execution of a kubectl command with a
@@ -18,4 +25,42 @@ func NewKubectl(kubeconfigPath string) *Kubectl {
 
 func (kubectl *Kubectl) Destroy() error {
 	return os.Remove(kubectl.KubeconfigPath)
+}
+
+func NewKubectlFromNode(host string) (*Kubectl, error) {
+	remoteFile := fmt.Sprintf("%s:/etc/kubernetes/admin.conf", host)
+
+	// Do not delete.
+	// Leave deletion up to destroying the kubectl instance.
+	tempFile, err := ioutil.TempFile("", "")
+	if err != nil {
+		return nil, err
+	}
+
+	// Close the file immediately, because it will be written by a subprocess.
+	if err := tempFile.Close(); err != nil {
+		return nil, err
+	}
+
+	if err = scp.ExecSCP(remoteFile, tempFile.Name()); err != nil {
+		return nil, err
+	}
+
+	kubectl := NewKubectl(tempFile.Name())
+	return kubectl, nil
+}
+
+func NewKubectlFromAnyNode(hosts []string) (*Kubectl, error) {
+	allErrorsStr := ""
+
+	for _, host := range hosts {
+		kubectl, err := NewKubectlFromNode(host)
+		if err == nil {
+			return kubectl, nil
+		}
+
+		allErrorsStr += "  " + err.Error() + "\n"
+	}
+
+	return nil, errors.New("Failed to find a kubeconfig file on any host:\n" + allErrorsStr)
 }


### PR DESCRIPTION
Nest commands that operate more against nodes themselves than against the cluster into their own nested subcommands for a bit more organization. 

Also moves the necessary things into pkg from utils to keep things accessible in the more nested structure.