### PR TITLE
Adds the ability to directly self-rehost docker images

### DIFF
--- a/cmd/hope/deploy.go
+++ b/cmd/hope/deploy.go
@@ -78,8 +78,6 @@ var deployCmd = &cobra.Command{
 			}
 		}
 
-		// Wait as long as possible before pulling the temporary kubectl from
-		//   a master node.
 		var kubectl *kubeutil.Kubectl
 		if hasKubernetesResource {
 			masters := viper.GetStringSlice("masters")
@@ -95,7 +93,7 @@ var deployCmd = &cobra.Command{
 
 		// TODO: Should be done in hope pkg
 		// TODO: Add validation to ensure each type of deployment can run given
-		//   the current dev environment -- ensure docker is can connect, etc.
+		//   the current dev environment -- ensure docker can connect, etc.
 		for _, resource := range *resources {
 			log.Debug("Starting deployment of ", resource.Name)
 			resourceType, err := resource.GetType()

--- a/cmd/hope/deploy.go
+++ b/cmd/hope/deploy.go
@@ -154,7 +154,6 @@ var deployCmd = &cobra.Command{
 				}
 
 				pullImage := ""
-
 				if isCacheCommand {
 					pullImage = resource.Build.Source
 				} else {

--- a/cmd/hope/root.go
+++ b/cmd/hope/root.go
@@ -155,6 +155,16 @@ func patchInvocations() {
 		return oldExecDocker(args...)
 	}
 
+	oldGetDocker := docker.GetDocker
+	docker.GetDocker = func(args ...string) (string, error) {
+		if docker.UseSudo {
+			log.Debug("sudo docker ", strings.Join(args, " "))
+		} else {
+			log.Debug("docker ", strings.Join(args, " "))
+		}
+		return oldGetDocker(args...)
+	}
+
 	oldEnvsubstBytes := envsubst.GetEnvsubstBytes
 	envsubst.GetEnvsubstBytes = func(args []string, contents []byte) ([]byte, error) {
 		argsKeys := []string{}

--- a/cmd/hope/utils.go
+++ b/cmd/hope/utils.go
@@ -28,7 +28,7 @@ type BuildSpec struct {
 	Path   string
 	Source string
 	Tag    string
-	Pull   bool
+	Pull   string
 }
 
 type ExecSpec struct {

--- a/cmd/hope/utils.go
+++ b/cmd/hope/utils.go
@@ -25,8 +25,10 @@ const (
 
 // Should be defined in hope pkg
 type BuildSpec struct {
-	Path string
-	Tag  string
+	Path   string
+	Source string
+	Tag    string
+	Pull   bool
 }
 
 type ExecSpec struct {
@@ -62,7 +64,7 @@ func (resource *Resource) GetType() (string, error) {
 	if len(resource.Inline) != 0 {
 		detectedTypes = append(detectedTypes, ResourceTypeInline)
 	}
-	if len(resource.Build.Path) != 0 && len(resource.Build.Tag) != 0 {
+	if (len(resource.Build.Path) != 0 || len(resource.Build.Source) != 0) && len(resource.Build.Tag) != 0 {
 		detectedTypes = append(detectedTypes, ResourceTypeDockerBuild)
 	}
 	if len(resource.Job) != 0 {

--- a/hope.yaml
+++ b/hope.yaml
@@ -66,6 +66,9 @@ resources:
   # Hope will optionally try to pull the image from the registry before
   #   building it in an attempt to save some compute time rebuilding layers 
   #   that haven't changed since the last push.
+  # Pull from source registry can be done in similar ways to Kubernetes'
+  #   Always and IfNotPresent with the "always", if "if-not-present" values.
+  # Like Kubernetes, defaults to "if-not-present".
   # Because docker builds tend to require a bit more state in them, providing a
   #   local path is all that's currently supported.
   # Now that Docker Hub has rolled out rate limits on their APIs, a Docker
@@ -74,13 +77,13 @@ resources:
   - name: build-some-image
     build:
       path: some-dir-with-dockerfile
-      pull: true
+      pull: always
       tag: registry.internal.aleemhaji.com/example-repo:latest
     tags: [app1]
   - name: copy-some-image
     build:
       source: python:3.7
-      pull: false
+      pull: if-not-present
       tag: registry.internal.aleemhaji.com/python:3.7
     tags: [dockercache]
   # When a spec comes with an initialization procedure, a job type can be used.

--- a/hope.yaml
+++ b/hope.yaml
@@ -63,16 +63,26 @@ resources:
   # Build and push a docker image to the registry.
   # Doesn't include a kubectl command at all, so that can be done in a step
   #   after a step like this appears.
-  # Hope will pull the latest image available from the registry before building
-  #   it in an attempt to save some compute time rebuilding layers that haven't
-  #   changed since the last deployment.
+  # Hope will optionally try to pull the image from the registry before
+  #   building it in an attempt to save some compute time rebuilding layers 
+  #   that haven't changed since the last push.
   # Because docker builds tend to require a bit more state in them, providing a
   #   local path is all that's currently supported.
+  # Now that Docker Hub has rolled out rate limits on their APIs, a Docker
+  #   build step also has the option to just copy an existing source tag, and
+  #   push it to the local registry.
   - name: build-some-image
     build:
       path: some-dir-with-dockerfile
+      pull: true
       tag: registry.internal.aleemhaji.com/example-repo:latest
     tags: [app1]
+  - name: copy-some-image
+    build:
+      source: python:3.7
+      pull: false
+      tag: registry.internal.aleemhaji.com/python:3.7
+    tags: [dockercache]
   # When a spec comes with an initialization procedure, a job type can be used.
   # These will wait until the job with the specified name is completed.
   # If the job fails, the deployment stops so that other resources that may

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -15,6 +15,7 @@ var UseSudo bool = false
 // is a lot nicer than
 //   docker.ExecDocker("pull", ...)
 type ExecDockerFunc func(args ...string) error
+type GetDockerFunc func(args ...string) (string, error)
 
 var ExecDocker ExecDockerFunc = func(args ...string) error {
 	var osCmd *exec.Cmd
@@ -29,6 +30,21 @@ var ExecDocker ExecDockerFunc = func(args ...string) error {
 	osCmd.Stderr = os.Stderr
 
 	return osCmd.Run()
+}
+
+var GetDocker GetDockerFunc = func(args ...string) (string, error) {
+	var osCmd *exec.Cmd
+	if UseSudo {
+		allArgs := append([]string{"docker"}, args...)
+		osCmd = exec.Command("sudo", allArgs...)
+	} else {
+		osCmd = exec.Command("docker", args...)
+	}
+	osCmd.Stdin = os.Stdin
+	osCmd.Stderr = os.Stderr
+
+	outputBytes, err := osCmd.Output()
+	return string(outputBytes), err
 }
 
 func SetUseSudo() {


### PR DESCRIPTION
With Docker Hub enabling rate limits, it's becoming increasingly necessary to limit the amount of `docker pull` operations executed against their registry. This change allows the hope file to specify some upstream images, and have them copied directly over to the local registry, so they can be referenced in all places.