### PR TITLE
Migrate over to a bit more rigid entities model

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
         "kubeadm",
         "kubeconfig",
         "kubectl",
+        "kubernetes",
         "kubeutil"
     ]
 }

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ EXECUTABLE := hope
 BIN_NAME := $(BUILD_DIR)/$(EXECUTABLE)
 INSTALLED_NAME := /usr/local/bin/$(EXECUTABLE)
 
-CMD_PACKAGE_DIR := ./cmd/hope
+CMD_PACKAGE_DIR := ./cmd/hope $(dir $(wildcard ./cmd/hope/*/))
 PKG_PACKAGE_DIR := ./pkg/*
 PACKAGE_PATHS := $(CMD_PACKAGE_DIR) $(PKG_PACKAGE_DIR)
 
-AUTOGEN_VERSION_FILENAME=$(CMD_PACKAGE_DIR)/version-temp.go
+AUTOGEN_VERSION_FILENAME=./cmd/hope/version-temp.go
 
 ALL_GO_DIRS = $(shell find . -iname "*.go" -exec dirname {} \; | sort | uniq)
 SRC := $(shell find . -iname "*.go" -and -not -name "*_test.go") $(AUTOGEN_VERSION_FILENAME)

--- a/cmd/hope/kubeconfig.go
+++ b/cmd/hope/kubeconfig.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 )
 
 import (
@@ -27,20 +28,12 @@ var kubeconfigCmd = &cobra.Command{
 
 		var master *hope.Node
 		if len(args) == 0 {
-			nodes, err := getNodes()
+			aMaster, err := getAnyMaster()
 			if err != nil {
 				return err
 			}
-	
-			for _, node := range *nodes {
-				if node.IsMaster() {
-					master = &node
-					break
-				}
-			}
-			if master == nil {
-				return errors.New("Failed to find any master in nodes config")
-			}
+
+			master = aMaster
 
 			log.Debug("No host given to kubeconfig command. Using first master from nodes list.")
 		} else {
@@ -50,6 +43,10 @@ var kubeconfigCmd = &cobra.Command{
 			}
 
 			master = aMaster
+		}
+
+		if !master.IsMaster() {
+			return errors.New(fmt.Sprintf("Node: %s is not a master node", master.Host))
 		}
 
 		log.Debug("Fetching admin kubeconfig file from ", master.Host)

--- a/cmd/hope/kubeconfig.go
+++ b/cmd/hope/kubeconfig.go
@@ -2,18 +2,15 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 )
 
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 import (
 	"github.com/Eagerod/hope/pkg/hope"
-	"github.com/Eagerod/hope/pkg/sliceutil"
 )
 
 var kubeconfigCmdMergeFlag bool
@@ -27,21 +24,36 @@ var kubeconfigCmd = &cobra.Command{
 	Short: "Fetch the kubeconfig from a master node",
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var masterIp string
-		masters := viper.GetStringSlice("masters")
-		if len(args) == 0 {
-			masterIp = masters[0]
-			log.Debug("No host given to kubeconfig command. Using first master from masters list.")
-		} else {
-			masterIp = args[0]
 
-			if !sliceutil.StringInSlice(masterIp, masters) {
-				return errors.New(fmt.Sprintf("Failed to find master %s in config", masterIp))
+		var master *hope.Node
+		if len(args) == 0 {
+			nodes, err := getNodes()
+			if err != nil {
+				return err
 			}
+	
+			for _, node := range *nodes {
+				if node.IsMaster() {
+					master = &node
+					break
+				}
+			}
+			if master == nil {
+				return errors.New("Failed to find any master in nodes config")
+			}
+
+			log.Debug("No host given to kubeconfig command. Using first master from nodes list.")
+		} else {
+			aMaster, err := getNode(args[0])
+			if err != nil {
+				return err
+			}
+
+			master = aMaster
 		}
 
-		log.Debug("Fetching admin kubeconfig file from ", masterIp)
+		log.Debug("Fetching admin kubeconfig file from ", master.Host)
 
-		return hope.FetchKubeconfig(log.WithFields(log.Fields{}), masterIp, kubeconfigCmdMergeFlag)
+		return hope.FetchKubeconfig(log.WithFields(log.Fields{}), master, kubeconfigCmdMergeFlag)
 	},
 }

--- a/cmd/hope/list.go
+++ b/cmd/hope/list.go
@@ -9,6 +9,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+import (
+	"github.com/Eagerod/hope/pkg/hope"
+)
+
 var listCmdTagSlice *[]string
 
 func initListCmdFlags() {
@@ -21,7 +25,7 @@ var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List resources that belong to a particular set of tags",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var resources *[]Resource
+		var resources *[]hope.Resource
 
 		if len(args) == 0 && len(*listCmdTagSlice) == 0 {
 			r, err := getResources()

--- a/cmd/hope/node/hostname.go
+++ b/cmd/hope/node/hostname.go
@@ -8,12 +8,10 @@ import (
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 import (
 	"github.com/Eagerod/hope/pkg/hope"
-	"github.com/Eagerod/hope/pkg/sliceutil"
 )
 
 var hostnameCmdForce bool

--- a/cmd/hope/node/hostname.go
+++ b/cmd/hope/node/hostname.go
@@ -27,18 +27,20 @@ var hostnameCmd = &cobra.Command{
 	Short: "Set the hostname on a node",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		host := args[0]
+		nodeName := args[0]
 		hostname := args[1]
 
-		isMaster := sliceutil.StringInSlice(host, viper.GetStringSlice("masters"))
-		isNode := sliceutil.StringInSlice(host, viper.GetStringSlice("nodes"))
-
-		if !isMaster && !isNode {
-			return errors.New(fmt.Sprintf("Host (%s) not found in list of masters or nodes.", host))
+		node, err := getNode(nodeName)
+		if err != nil {
+			return err
 		}
 
-		log.Info("Setting hostname on node ", host, " to ", hostname)
+		if !node.IsRoleValid() {
+			return errors.New(fmt.Sprintf("Node %s has invalid role %s.", node.Name, node.Role))
+		}
 
-		return hope.SetHostname(log.WithFields(log.Fields{}), host, hostname, hostnameCmdForce)
+		log.Info("Setting hostname on node ", node.Name, "(", node.Host, ")", " to ", hostname)
+
+		return hope.SetHostname(log.WithFields(log.Fields{}), node, hostname, hostnameCmdForce)
 	},
 }

--- a/cmd/hope/node/init.go
+++ b/cmd/hope/node/init.go
@@ -47,7 +47,7 @@ var initCmd = &cobra.Command{
 
 			defer kubectl.Destroy()
 
-			if err := hope.TaintNodeByHost(kubectl, node.Host, "node-role.kubernetes.io/master:NoSchedule-"); err != nil {
+			if err := hope.TaintNodeByHost(kubectl, node, "node-role.kubernetes.io/master:NoSchedule-"); err != nil {
 				return err
 			}
 		} else if node.IsMaster() {

--- a/cmd/hope/node/init.go
+++ b/cmd/hope/node/init.go
@@ -3,7 +3,6 @@ package node
 import (
 	"errors"
 	"fmt"
-	"net/url"
 )
 
 import (
@@ -15,7 +14,6 @@ import (
 import (
 	"github.com/Eagerod/hope/pkg/hope"
 	"github.com/Eagerod/hope/pkg/kubeutil"
-	"github.com/Eagerod/hope/pkg/sliceutil"
 )
 
 var initCmd = &cobra.Command{
@@ -23,12 +21,9 @@ var initCmd = &cobra.Command{
 	Short: "Bootstrap a node within the cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		host := args[0]
+		nodeName := args[0]
 
-		// URL parsing is a bit better at identifying parameters if there's a
-		//   protocol on the string passed in, so fake in ssh as the protocol to
-		//   help it parse a little more reliably.
-		host_url, err := url.Parse(fmt.Sprintf("ssh://%s", host))
+		node, err := getNode(nodeName)
 		if err != nil {
 			return err
 		}
@@ -38,13 +33,10 @@ var initCmd = &cobra.Command{
 		podNetworkCidr := viper.GetString("pod_network_cidr")
 		masters := viper.GetStringSlice("masters")
 
-		isMaster := sliceutil.StringInSlice(host, masters)
-		isWorker := sliceutil.StringInSlice(host, viper.GetStringSlice("nodes"))
+		if node.IsMasterAndNode() {
+			log.Info("Node ", node.Host, " appears to be both master and node. Creating master and removing NoSchedule taint...")
 
-		if isMaster && isWorker {
-			log.Info("Node ", host, " appears in both master and node configurations. Creating master and removing NoSchedule taint...")
-
-			if err := hope.CreateClusterMaster(log.WithFields(log.Fields{}), host, podNetworkCidr); err != nil {
+			if err := hope.CreateClusterMaster(log.WithFields(log.Fields{}), node, podNetworkCidr); err != nil {
 				return err
 			}
 
@@ -55,20 +47,20 @@ var initCmd = &cobra.Command{
 
 			defer kubectl.Destroy()
 
-			if err := hope.TaintNodeByHost(kubectl, host_url.Host, "node-role.kubernetes.io/master:NoSchedule-"); err != nil {
+			if err := hope.TaintNodeByHost(kubectl, node.Host, "node-role.kubernetes.io/master:NoSchedule-"); err != nil {
 				return err
 			}
-		} else if isMaster {
-			return hope.CreateClusterMaster(log.WithFields(log.Fields{}), host, podNetworkCidr)
-		} else if isWorker {
+		} else if node.IsMaster() {
+			return hope.CreateClusterMaster(log.WithFields(log.Fields{}), node, podNetworkCidr)
+		} else if node.IsNode() {
 			// Have to send in a master ip for it to grab a join token.
 			aMaster := masters[0]
 
-			if err := hope.CreateClusterNode(log.WithFields(log.Fields{}), host, aMaster); err != nil {
+			if err := hope.CreateClusterNode(log.WithFields(log.Fields{}), node, aMaster); err != nil {
 				return err
 			}
 		} else {
-			return errors.New(fmt.Sprintf("Failed to find node %s in config", host))
+			return errors.New(fmt.Sprintf("Failed to find node %s in config", nodeName))
 		}
 
 		return nil

--- a/cmd/hope/node/reset.go
+++ b/cmd/hope/node/reset.go
@@ -58,6 +58,6 @@ var resetCmd = &cobra.Command{
 
 		// TODO: may need to add more validation, like that this isn't the
 		//   only master and is being removed, unless force is provided.
-		return hope.KubeadmResetRemote(log.WithFields(log.Fields{}), kubectl, node.Host, resetCmdForce)
+		return hope.KubeadmResetRemote(log.WithFields(log.Fields{}), kubectl, node, resetCmdForce)
 	},
 }

--- a/cmd/hope/node/reset.go
+++ b/cmd/hope/node/reset.go
@@ -14,7 +14,6 @@ import (
 import (
 	"github.com/Eagerod/hope/pkg/hope"
 	"github.com/Eagerod/hope/pkg/kubeutil"
-	"github.com/Eagerod/hope/pkg/sliceutil"
 )
 
 var resetCmdForce bool
@@ -28,14 +27,16 @@ var resetCmd = &cobra.Command{
 	Short: "Attempts to gracefully run kubeadm reset on the specified host",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		host := args[0]
+		nodeName := args[0]
 		masters := viper.GetStringSlice("masters")
 
-		isMaster := sliceutil.StringInSlice(host, masters)
-		isNode := sliceutil.StringInSlice(host, viper.GetStringSlice("nodes"))
+		node, err := getNode(nodeName)
+		if err != nil {
+			return err
+		}
 
-		if !isMaster && !isNode {
-			return errors.New(fmt.Sprintf("Host (%s) not found in list of masters or nodes.", host))
+		if !node.IsRoleValid() {
+			return errors.New(fmt.Sprintf("Host (%s) not found in list of masters or nodes.", node.Host))
 		}
 
 		// If force is set, failing to find a kubeconfig shouldn't stop the
@@ -57,6 +58,6 @@ var resetCmd = &cobra.Command{
 
 		// TODO: may need to add more validation, like that this isn't the
 		//   only master and is being removed, unless force is provided.
-		return hope.KubeadmResetRemote(log.WithFields(log.Fields{}), kubectl, host, resetCmdForce)
+		return hope.KubeadmResetRemote(log.WithFields(log.Fields{}), kubectl, node.Host, resetCmdForce)
 	},
 }

--- a/cmd/hope/node/root.go
+++ b/cmd/hope/node/root.go
@@ -18,5 +18,4 @@ func InitNodeCommand() {
 
 	initHostnameCmdFlags()
 	initResetCmd()
-	initSshCmd()
 }

--- a/cmd/hope/node/ssh.go
+++ b/cmd/hope/node/ssh.go
@@ -1,33 +1,25 @@
 package node
 
 import (
-	"errors"
-	"fmt"
-)
-
-import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 import (
 	"github.com/Eagerod/hope/pkg/hope"
-	"github.com/Eagerod/hope/pkg/sliceutil"
 )
-
-var sshCmdForce bool
-
-func initSshCmd() {
-	sshCmd.Flags().BoolVarP(&sshCmdForce, "force", "", false, "set up SSH even if the node isn't a part of the cluster")
-}
 
 var sshCmd = &cobra.Command{
 	Use:   "ssh",
 	Short: "Initializes SSH for the given host",
 	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		host := args[0]
+		nodeName := args[0]
+
+		node, err := getNode(nodeName)
+		if err != nil {
+			return err
+		}
 
 		// If a second argument is given, instead of trying to verify
 		//   that the current host can SSH in without password, assume
@@ -35,20 +27,11 @@ var sshCmd = &cobra.Command{
 		//   path to the remote.
 		hasKeyArg := len(args) == 2
 
-		isMaster := sliceutil.StringInSlice(host, viper.GetStringSlice("masters"))
-		isNode := sliceutil.StringInSlice(host, viper.GetStringSlice("nodes"))
-
-		if !isMaster && !isNode {
-			if !sshCmdForce {
-				return errors.New(fmt.Sprintf("Host (%s) not found in list of masters or nodes.", host))
-			}
-		}
-
 		if hasKeyArg {
 			localKeyPath := args[1]
-			return hope.CopySSHKeyToAuthorizedKeys(log.WithFields(log.Fields{}), localKeyPath, host)
+			return hope.CopySSHKeyToAuthorizedKeys(log.WithFields(log.Fields{}), localKeyPath, node)
 		}
 
-		return hope.EnsureSSHWithoutPassword(log.WithFields(log.Fields{}), host)
+		return hope.EnsureSSHWithoutPassword(log.WithFields(log.Fields{}), node)
 	},
 }

--- a/cmd/hope/node/utils.go
+++ b/cmd/hope/node/utils.go
@@ -1,0 +1,47 @@
+package node
+
+import (
+	"errors"
+	"fmt"
+)
+
+import (
+	"github.com/spf13/viper"
+)
+
+import (
+	"github.com/Eagerod/hope/pkg/hope"
+)
+
+// Copied directly from the parent package.
+// Need to find the canonical way of distributing cmd-only code to nested
+//   packages
+func getNodes() (*[]hope.Node, error) {
+	var nodes []hope.Node
+	err := viper.UnmarshalKey("nodes", &nodes)
+
+	nameMap := map[string]bool{}
+	for _, node := range nodes {
+		if _, ok := nameMap[node.Name]; ok {
+			return nil, errors.New(fmt.Sprintf("Multiple nodes found in configuration file named: %s", node.Name))
+		}
+		nameMap[node.Name] = true
+	}
+
+	return &nodes, err
+}
+
+func getNode(name string) (*hope.Node, error) {
+	nodes, err := getNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, node := range *nodes {
+		if node.Name == name {
+			return &node, nil
+		}
+	}
+
+	return nil, errors.New(fmt.Sprintf("Failed to find a node named %s", name))
+}

--- a/cmd/hope/node/utils_test.go
+++ b/cmd/hope/node/utils_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/Eagerod/hope/pkg/hope"
 )
 
-// Basically a smoke test, don't want to define a ton of yaml blocks to test
-//   this extensively quite yet.
-func TestGetNodes(t *testing.T) {
+func resetViper(t *testing.T) {
+	viper.Reset()
+
 	// Assume config file in the project root.
 	// Probably bad practice, but better test than having nothing at all.
 	viper.AddConfigPath("../../../")
@@ -24,6 +24,12 @@ func TestGetNodes(t *testing.T) {
 
 	err := viper.ReadInConfig()
 	assert.Nil(t, err)
+}
+
+// Basically a smoke test, don't want to define a ton of yaml blocks to test
+//   this extensively quite yet.
+func TestGetNodes(t *testing.T) {
+	resetViper(t)
 
 	nodes, err := getNodes()
 	assert.Nil(t, err)
@@ -48,14 +54,7 @@ func TestGetNodes(t *testing.T) {
 }
 
 func TestGetNode(t *testing.T) {
-	// Assume config file in the project root.
-	// Probably bad practice, but better test than having nothing at all.
-	viper.AddConfigPath("../../../")
-	viper.SetConfigName("hope")
-	viper.AutomaticEnv()
-
-	err := viper.ReadInConfig()
-	assert.Nil(t, err)
+	resetViper(t)
 
 	nodes, err := getNodes()
 	assert.Nil(t, err)

--- a/cmd/hope/node/utils_test.go
+++ b/cmd/hope/node/utils_test.go
@@ -1,0 +1,79 @@
+package node
+
+import (
+	"testing"
+)
+
+import (
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/Eagerod/hope/pkg/hope"
+)
+
+// Basically a smoke test, don't want to define a ton of yaml blocks to test
+//   this extensively quite yet.
+func TestGetNodes(t *testing.T) {
+	// Assume config file in the project root.
+	// Probably bad practice, but better test than having nothing at all.
+	viper.AddConfigPath("../../../")
+	viper.SetConfigName("hope")
+	viper.AutomaticEnv()
+
+	err := viper.ReadInConfig()
+	assert.Nil(t, err)
+
+	nodes, err := getNodes()
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(*nodes))
+
+	expected := []hope.Node{
+		hope.Node{
+			Name: "home-master-01",
+			Role: "master",
+			Host: "192.168.1.31",
+			User: "root",
+		},
+		hope.Node{
+			Name: "home-node-01",
+			Role: "node",
+			Host: "192.168.1.30",
+			User: "root",
+		},
+	}
+
+	assert.Equal(t, *nodes, expected)
+}
+
+func TestGetNode(t *testing.T) {
+	// Assume config file in the project root.
+	// Probably bad practice, but better test than having nothing at all.
+	viper.AddConfigPath("../../../")
+	viper.SetConfigName("hope")
+	viper.AutomaticEnv()
+
+	err := viper.ReadInConfig()
+	assert.Nil(t, err)
+
+	nodes, err := getNodes()
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(*nodes))
+
+	var tests = []struct {
+		name     string
+		nodeName string
+		node     hope.Node
+	}{
+		{"Get home-master-01", "home-master-01", hope.Node{Name: "home-master-01", Role: "master", Host: "192.168.1.31", User: "root"}},
+		{"Get home-node-01", "home-node-01", hope.Node{Name: "home-node-01", Role: "node", Host: "192.168.1.30", User: "root"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node, err := getNode(tt.nodeName)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.node, *node)
+		})
+	}
+}

--- a/cmd/hope/remove.go
+++ b/cmd/hope/remove.go
@@ -64,7 +64,7 @@ var removeCmd = &cobra.Command{
 			//   templated values, so still do the environment substitution
 			//   process.
 			switch resourceType {
-			case ResourceTypeFile:
+			case hope.ResourceTypeFile:
 				if len(resource.Parameters) != 0 {
 					content, err := replaceParametersInFile(resource.File, resource.Parameters)
 					if err != nil {
@@ -80,7 +80,7 @@ var removeCmd = &cobra.Command{
 						return err
 					}
 				}
-			case ResourceTypeInline:
+			case hope.ResourceTypeInline:
 				inline := resource.Inline
 
 				// Log out the inline resource before substituting it; secrets
@@ -99,11 +99,11 @@ var removeCmd = &cobra.Command{
 				if err := hope.KubectlDeleteStdIn(kubectl, inline); err != nil {
 					return err
 				}
-			case ResourceTypeDockerBuild:
+			case hope.ResourceTypeDockerBuild:
 				log.Debug("Skipping removal of docker image.")
-			case ResourceTypeJob:
+			case hope.ResourceTypeJob:
 				log.Debug("Skipping removal of job resource type.")
-			case ResourceTypeExec:
+			case hope.ResourceTypeExec:
 				log.Debug("Skipping removal of exec resource type.")
 			default:
 				return errors.New(fmt.Sprintf("Resource type (%s) not implemented.", resourceType))

--- a/cmd/hope/utils.go
+++ b/cmd/hope/utils.go
@@ -90,6 +90,21 @@ func getNode(name string) (*hope.Node, error) {
 	return nil, errors.New(fmt.Sprintf("Failed to find a node named %s", name))
 }
 
+func getAnyMaster() (*hope.Node, error) {
+	nodes, err := getNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, node := range *nodes {
+		if node.IsMaster() {
+			return &node, nil
+		}
+	}
+
+	return nil, errors.New("Failed to find any master in nodes config")
+}
+
 func replaceParametersInString(str string, parameters []string) (string, error) {
 	t := hope.NewTextSubstitutorFromString(str)
 	return replaceParametersWithSubstitutor(t, parameters)

--- a/cmd/hope/utils.go
+++ b/cmd/hope/utils.go
@@ -30,19 +30,64 @@ func getResources() (*[]hope.Resource, error) {
 	return &resources, err
 }
 
-func getJob(jobName string) (*hope.Job, error) {
+func getJobs() (*[]hope.Job, error) {
 	var jobs []hope.Job
 	err := viper.UnmarshalKey("jobs", &jobs)
+
+	nameMap := map[string]bool{}
+	for _, job := range jobs {
+		if _, ok := nameMap[job.Name]; ok {
+			return nil, errors.New(fmt.Sprintf("Multiple jobs found in configuration file named: %s", job.Name))
+		}
+		nameMap[job.Name] = true
+	}
+
+	return &jobs, err
+}
+
+func getJob(jobName string) (*hope.Job, error) {
+	jobs, err := getJobs()
 	if err != nil {
 		return nil, err
 	}
 
-	for _, job := range jobs {
+	for _, job := range *jobs {
 		if job.Name == jobName {
 			return &job, nil
 		}
 	}
+
 	return nil, errors.New(fmt.Sprintf("Failed to find a job named %s", jobName))
+}
+
+func getNodes() (*[]hope.Node, error) {
+	var nodes []hope.Node
+	err := viper.UnmarshalKey("nodes", &nodes)
+
+	nameMap := map[string]bool{}
+	for _, node := range nodes {
+		if _, ok := nameMap[node.Name]; ok {
+			return nil, errors.New(fmt.Sprintf("Multiple nodes found in configuration file named: %s", node.Name))
+		}
+		nameMap[node.Name] = true
+	}
+
+	return &nodes, err
+}
+
+func GetNode(name string) (*hope.Node, error) {
+	nodes, err := getNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, node := range *nodes {
+		if node.Name == name {
+			return &node, nil
+		}
+	}
+
+	return nil, errors.New(fmt.Sprintf("Failed to find a node named %s", name))
 }
 
 func replaceParametersInString(str string, parameters []string) (string, error) {

--- a/cmd/hope/utils.go
+++ b/cmd/hope/utils.go
@@ -75,7 +75,7 @@ func getNodes() (*[]hope.Node, error) {
 	return &nodes, err
 }
 
-func GetNode(name string) (*hope.Node, error) {
+func getNode(name string) (*hope.Node, error) {
 	nodes, err := getNodes()
 	if err != nil {
 		return nil, err

--- a/cmd/hope/utils_test.go
+++ b/cmd/hope/utils_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+import (
+	"github.com/Eagerod/hope/pkg/hope"
+)
+
 func TestReplaceParametersInString(t *testing.T) {
 	os.Setenv("HELLO", "Hello,")
 	os.Setenv("WORLD", "World!")
@@ -83,6 +87,71 @@ func TestGetIdentifiableResources(t *testing.T) {
 			resources, err := getIdentifiableResources(&tt.names, &tt.tags)
 			assert.Nil(t, err)
 			assert.Equal(t, tt.expected, len(*resources))
+		})
+	}
+}
+
+// Basically a smoke test, don't want to define a ton of yaml blocks to test
+//   this extensively quite yet.
+func TestGetNodes(t *testing.T) {
+	// Assume config file in the project root.
+	// Probably bad practice, but better test than having nothing at all.
+	viper.AddConfigPath("../../../")
+	viper.SetConfigName("hope")
+	viper.AutomaticEnv()
+
+	err := viper.ReadInConfig()
+	assert.Nil(t, err)
+
+	nodes, err := getNodes()
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(*nodes))
+
+	expected := []hope.Node{
+		hope.Node{
+			Name: "home-master-01",
+			Role: "master",
+			Host: "192.168.1.31",
+			User: "root",
+		},
+		hope.Node{
+			Name: "home-node-01",
+			Role: "node",
+			Host: "192.168.1.30",
+			User: "root",
+		},
+	}
+
+	assert.Equal(t, *nodes, expected)
+}
+
+func TestGetNode(t *testing.T) {
+	// Assume config file in the project root.
+	// Probably bad practice, but better test than having nothing at all.
+	viper.AddConfigPath("../../../")
+	viper.SetConfigName("hope")
+	viper.AutomaticEnv()
+
+	err := viper.ReadInConfig()
+	assert.Nil(t, err)
+
+	nodes, err := getNodes()
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(*nodes))
+
+	var tests = []struct {
+		name     string
+		nodeName string
+		node     hope.Node
+	}{
+		{"Get home-master-01", "home-master-01", hope.Node{Name: "home-master-01", Role: "master", Host: "192.168.1.31", User: "root"}},
+		{"Get home-node-01", "home-node-01", hope.Node{Name: "home-node-01", Role: "node", Host: "192.168.1.30", User: "root"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node, err := getNode(tt.nodeName)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.node, *node)
 		})
 	}
 }

--- a/cmd/hope/utils_test.go
+++ b/cmd/hope/utils_test.go
@@ -14,6 +14,19 @@ import (
 	"github.com/Eagerod/hope/pkg/hope"
 )
 
+func resetViper(t *testing.T) {
+	viper.Reset()
+
+	// Assume config file in the project root.
+	// Probably bad practice, but better test than having nothing at all.
+	viper.AddConfigPath("../../")
+	viper.SetConfigName("hope")
+	viper.AutomaticEnv()
+
+	err := viper.ReadInConfig()
+	assert.Nil(t, err)
+}
+
 func TestReplaceParametersInString(t *testing.T) {
 	os.Setenv("HELLO", "Hello,")
 	os.Setenv("WORLD", "World!")
@@ -44,14 +57,7 @@ func TestReplaceParametersInString(t *testing.T) {
 // Basically a smoke test, don't want to define a ton of yaml blocks to test
 //   this extensively quite yet.
 func TestGetResources(t *testing.T) {
-	// Assume config file in the project root.
-	// Probably bad practice, but better test than having nothing at all.
-	viper.AddConfigPath("../../")
-	viper.SetConfigName("hope")
-	viper.AutomaticEnv()
-
-	err := viper.ReadInConfig()
-	assert.Nil(t, err)
+	resetViper(t)
 
 	resources, err := getResources()
 	assert.Nil(t, err)
@@ -59,14 +65,7 @@ func TestGetResources(t *testing.T) {
 }
 
 func TestGetIdentifiableResources(t *testing.T) {
-	// Assume config file in the project root.
-	// Probably bad practice, but better test than having nothing at all.
-	viper.AddConfigPath("../../")
-	viper.SetConfigName("hope")
-	viper.AutomaticEnv()
-
-	err := viper.ReadInConfig()
-	assert.Nil(t, err)
+	resetViper(t)
 
 	var tests = []struct {
 		name     string
@@ -94,14 +93,7 @@ func TestGetIdentifiableResources(t *testing.T) {
 // Basically a smoke test, don't want to define a ton of yaml blocks to test
 //   this extensively quite yet.
 func TestGetNodes(t *testing.T) {
-	// Assume config file in the project root.
-	// Probably bad practice, but better test than having nothing at all.
-	viper.AddConfigPath("../../../")
-	viper.SetConfigName("hope")
-	viper.AutomaticEnv()
-
-	err := viper.ReadInConfig()
-	assert.Nil(t, err)
+	resetViper(t)
 
 	nodes, err := getNodes()
 	assert.Nil(t, err)
@@ -126,14 +118,7 @@ func TestGetNodes(t *testing.T) {
 }
 
 func TestGetNode(t *testing.T) {
-	// Assume config file in the project root.
-	// Probably bad practice, but better test than having nothing at all.
-	viper.AddConfigPath("../../../")
-	viper.SetConfigName("hope")
-	viper.AutomaticEnv()
-
-	err := viper.ReadInConfig()
-	assert.Nil(t, err)
+	resetViper(t)
 
 	nodes, err := getNodes()
 	assert.Nil(t, err)

--- a/hope.yaml
+++ b/hope.yaml
@@ -1,10 +1,15 @@
 access_points:
   - 192.168.2.43
 access_point_controller: http://192.168.2.10:8080
-masters:
-  - root@192.168.1.31
 nodes:
-  - root@192.168.1.30
+  - name: home-master-01
+    role: master
+    hostname: 192.168.1.31
+    user: root
+  - name: home-node-01
+    role: node
+    hostname: 192.168.1.30
+    user: root
 loglevel: trace
 pod_network_cidr: 10.244.0.0/16
 # Resource list of all things to deploy to the cluster, and the order in which

--- a/hope.yaml
+++ b/hope.yaml
@@ -4,11 +4,11 @@ access_point_controller: http://192.168.2.10:8080
 nodes:
   - name: home-master-01
     role: master
-    hostname: 192.168.1.31
+    host: 192.168.1.31
     user: root
   - name: home-node-01
     role: node
-    hostname: 192.168.1.30
+    host: 192.168.1.30
     user: root
 loglevel: trace
 pod_network_cidr: 10.244.0.0/16

--- a/pkg/hope/entities.go
+++ b/pkg/hope/entities.go
@@ -157,7 +157,7 @@ func (node *Node) IsNode() bool {
 	return node.Role == "node" || node.IsMasterAndNode()
 }
 
-// IsValidRole - Whether or not the node has a role that has been implemented.
-func (node *Node) IsValidRole() bool {
+// IsRoleValid - Whether or not the node has a role that has been implemented.
+func (node *Node) IsRoleValid() bool {
 	return node.IsMaster() || node.IsNode()
 }

--- a/pkg/hope/entities.go
+++ b/pkg/hope/entities.go
@@ -156,3 +156,8 @@ func (node *Node) IsMaster() bool {
 func (node *Node) IsNode() bool {
 	return node.Role == "node" || node.IsMasterAndNode()
 }
+
+// IsValidRole - Whether or not the node has a role that has been implemented.
+func (node *Node) IsValidRole() bool {
+	return node.IsMaster() || node.IsNode()
+}

--- a/pkg/hope/entities.go
+++ b/pkg/hope/entities.go
@@ -72,6 +72,15 @@ type Job struct {
 	Parameters []string
 }
 
+// Node - Defines a networked resource on which operations will typically be
+//   executed.
+type Node struct {
+	Name string
+	Role string
+	Host string
+	User string
+}
+
 func (rt ResourceType) String() string {
 	switch rt {
 	case ResourceTypeFile:
@@ -121,4 +130,29 @@ func (resource *Resource) GetType() (ResourceType, error) {
 		}
 		return ResourceTypeUnknown, fmt.Errorf("Detected multiple types for resource '%s': %s", resource.Name, strings.Join(detectedTypeStrings, ", "))
 	}
+}
+
+// ConnectionString - Get the node's connection string
+func (node *Node) ConnectionString() string {
+	if node.User != "" {
+		return fmt.Sprintf("%s:%s", node.User, node.Host)
+	}
+
+	return node.Host
+}
+
+// IsMasterAndNode - Whether or not this node plays the roles of both control
+//   plane and worker node.
+func (node *Node) IsMasterAndNode() bool {
+	return node.Role == "master+node"
+}
+
+// IsMaster - Whether or not this node is a control plane node.
+func (node *Node) IsMaster() bool {
+	return node.Role == "master" || node.IsMasterAndNode()
+}
+
+// IsNode - Whether or not this node is a worker node.
+func (node *Node) IsNode() bool {
+	return node.Role == "node" || node.IsMasterAndNode()
 }

--- a/pkg/hope/entities.go
+++ b/pkg/hope/entities.go
@@ -1,0 +1,124 @@
+package hope
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ResourceType enum to differentiate the types of resource definitions that
+//   can appear in the hope yaml file.
+type ResourceType int
+
+const (
+	// ResourceTypeUnknown - No resource type could be determined for the
+	//   resource being evaluated.
+	ResourceTypeUnknown ResourceType = iota
+
+	// ResourceTypeFile - Provide a path to a local file/URL to a remote file
+	//    to apply.
+	ResourceTypeFile
+
+	// ResourceTypeInline - Provide an inline yaml definition of resources to
+	//   apply.
+	ResourceTypeInline
+
+	// ResourceTypeDockerBuild - Build a docker image with the given context
+	//   path, and push it to the specified repository.
+	ResourceTypeDockerBuild
+
+	// ResourceTypeJob - Wait for a job with the given name to finish
+	//   executing.
+	ResourceTypeJob
+
+	// ResourceTypeExec - Execute a script in a running pod/container.
+	ResourceTypeExec
+)
+
+// BuildSpec - Properties of a ResourceTypeDockerBuild
+type BuildSpec struct {
+	Path   string
+	Source string
+	Tag    string
+	Pull   string
+}
+
+// ExecSpec - Properties of a ResourceTypeExec
+type ExecSpec struct {
+	Selector string
+	Timeout  string
+	Command  []string
+}
+
+// Resource - Properties that can appear in any resources.
+// There may be a better way of doing this, but with a pretty generic list of
+//   items appearing in a yaml file, maybe not.
+type Resource struct {
+	Name       string
+	File       string
+	Inline     string
+	Parameters []string
+	Build      BuildSpec
+	Job        string
+	Exec       ExecSpec
+	Tags       []string
+}
+
+// Job - Properties that can appear in any ephemeral job definition.
+// TODO: Allow jobs to define max retry parameters, or accept them on the
+//   command line.
+type Job struct {
+	Name       string
+	File       string
+	Parameters []string
+}
+
+func (rt ResourceType) String() string {
+	switch rt {
+	case ResourceTypeFile:
+		return "file"
+	case ResourceTypeInline:
+		return "inline"
+	case ResourceTypeDockerBuild:
+		return "docker"
+	case ResourceTypeJob:
+		return "job"
+	case ResourceTypeExec:
+		return "exec"
+	}
+
+	return "UNDEFINED"
+}
+
+// GetType - Scan through defined properties, and return the resource type
+//   that the resource appears to implement.
+func (resource *Resource) GetType() (ResourceType, error) {
+	detectedTypes := []ResourceType{}
+	if len(resource.File) != 0 {
+		detectedTypes = append(detectedTypes, ResourceTypeFile)
+	}
+	if len(resource.Inline) != 0 {
+		detectedTypes = append(detectedTypes, ResourceTypeInline)
+	}
+	if (len(resource.Build.Path) != 0 || len(resource.Build.Source) != 0) && len(resource.Build.Tag) != 0 {
+		detectedTypes = append(detectedTypes, ResourceTypeDockerBuild)
+	}
+	if len(resource.Job) != 0 {
+		detectedTypes = append(detectedTypes, ResourceTypeJob)
+	}
+	if len(resource.Exec.Selector) != 0 && len(resource.Exec.Command) != 0 {
+		detectedTypes = append(detectedTypes, ResourceTypeExec)
+	}
+
+	switch len(detectedTypes) {
+	case 0:
+		return ResourceTypeUnknown, fmt.Errorf("Failed to find type of resource '%s'", resource.Name)
+	case 1:
+		return detectedTypes[0], nil
+	default:
+		detectedTypeStrings := []string{}
+		for _, i := range detectedTypes {
+			detectedTypeStrings = append(detectedTypeStrings, i.String())
+		}
+		return ResourceTypeUnknown, fmt.Errorf("Detected multiple types for resource '%s': %s", resource.Name, strings.Join(detectedTypeStrings, ", "))
+	}
+}

--- a/pkg/hope/node_management.go
+++ b/pkg/hope/node_management.go
@@ -133,9 +133,8 @@ func CreateClusterNode(log *logrus.Entry, node *Node, masterIp string) error {
 		return err
 	}
 
-	connectionString := node.ConnectionString()
 	joinComponents := strings.Split(joinCommand, " ")
-	allArguments := append([]string{connectionString}, joinComponents...)
+	allArguments := append([]string{node.ConnectionString()}, joinComponents...)
 	if err := ssh.ExecSSH(allArguments...); err != nil {
 		return err
 	}

--- a/pkg/hope/node_management.go
+++ b/pkg/hope/node_management.go
@@ -19,7 +19,7 @@ import (
 )
 
 func setupCommonNodeRequirements(log *logrus.Entry, node *Node) error {
-	if node.Role != "master" && node.Role != "node" && node.Role != "master+node" {
+	if !node.IsRoleValid() {
 		return errors.New(fmt.Sprintf("Node has role %s, should not prepare as Kubernetes node.", node.Role))
 	}
 
@@ -94,7 +94,7 @@ func setupCommonNodeRequirements(log *logrus.Entry, node *Node) error {
 }
 
 func CreateClusterMaster(log *logrus.Entry, node *Node, podNetworkCidr string) error {
-	if node.Role != "master" && node.Role != "master+node" {
+	if !node.IsMaster() {
 		return errors.New(fmt.Sprintf("Node has role %s and should not be set up as a Kubernetes master", node.Role))
 	}
 
@@ -116,7 +116,7 @@ func CreateClusterMaster(log *logrus.Entry, node *Node, podNetworkCidr string) e
 }
 
 func CreateClusterNode(log *logrus.Entry, node *Node, masterIp string) error {
-	if node.Role != "node" && node.Role != "master+node" {
+	if !node.IsNode() {
 		return errors.New(fmt.Sprintf("Node has role %s and should not be set up as a Kubernetes node", node.Role))
 	}
 

--- a/pkg/hope/node_management.go
+++ b/pkg/hope/node_management.go
@@ -156,7 +156,7 @@ func TaintNodeByHost(kubectl *kubeutil.Kubectl, host string, taint string) error
 	return nil
 }
 
-func SetHostname(log *logrus.Entry, node Node, hostname string, force bool) error {
+func SetHostname(log *logrus.Entry, node *Node, hostname string, force bool) error {
 	connectionString := node.ConnectionString()
 
 	existingHostname, err := ssh.GetSSH(connectionString, "hostname")

--- a/pkg/hope/remote_kubeconfig.go
+++ b/pkg/hope/remote_kubeconfig.go
@@ -15,13 +15,14 @@ import (
 	"github.com/Eagerod/hope/pkg/kubeutil"
 )
 
-func FetchKubeconfig(log *logrus.Entry, host string, merge bool) error {
+func FetchKubeconfig(log *logrus.Entry, node *Node, merge bool) error {
 	kubeconfigFile, err := kubeutil.GetKubeConfigPath()
 	if err != nil {
 		return err
 	}
 
-	kubectl, err := kubeutil.NewKubectlFromNode(host)
+	connectionString := node.ConnectionString()
+	kubectl, err := kubeutil.NewKubectlFromNode(connectionString)
 	if err != nil {
 		return err
 	}
@@ -52,7 +53,7 @@ func FetchKubeconfig(log *logrus.Entry, host string, merge bool) error {
 		return err
 	}
 
-	log.Debug("Merging existing KUBECONFIG file with file downloaded from ", host)
+	log.Debug("Merging existing KUBECONFIG file with file downloaded from ", connectionString)
 
 	combinerKubeconfig := kubeutil.NewKubectl(kubeconfigFile + ":" + kubectl.KubeconfigPath)
 	kubeconfigContents, err := kubeutil.GetKubectl(combinerKubeconfig, "config", "view", "--raw")


### PR DESCRIPTION
Migrates a lot of passing back and fourth of just a hostname to instead use a model that holds a bit more than just the hostname. 

Should make things a little more flexible, and will make the eventual move of a bunch of logic from `cmd/hope` to `pkg/hope` a lot more straight-forward.