### PR TITLE
Testability

### DIFF
--- a/cmd/hope/vm/delete.go
+++ b/cmd/hope/vm/delete.go
@@ -1,0 +1,48 @@
+package vm
+
+import (
+	"fmt"
+)
+
+import (
+	"github.com/spf13/cobra"
+)
+
+import (
+	"github.com/Eagerod/hope/cmd/hope/utils"
+	"github.com/Eagerod/hope/pkg/esxi"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a VM on the specified host.",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		hypervisorName := args[0]
+		vmName := args[1]
+
+		hypervisor, err := utils.GetNode(hypervisorName)
+		if err != nil {
+			return err
+		}
+
+		if !hypervisor.IsHypervisor() {
+			return fmt.Errorf("Node %s is not a hypervisor; cannot delete a VM on it", hypervisor.Name)
+		}
+
+		connectionString := hypervisor.ConnectionString()
+
+		// If the VM is on, don't allow the user to proceed, and force them to
+		//   shut it off themselves.
+		powerState, err := esxi.PowerStateOfVmNamed(connectionString, vmName)
+		if err != nil {
+			return err
+		}
+
+		if powerState != esxi.VmStatePoweredOff {
+			return fmt.Errorf("VM %s has power state: %s; cannot delete", vmName, powerState)
+		}
+
+		return esxi.DeleteVmNamed(connectionString, vmName)
+	},
+}

--- a/cmd/hope/vm/list.go
+++ b/cmd/hope/vm/list.go
@@ -26,7 +26,7 @@ var listCmd = &cobra.Command{
 		}
 
 		if !hypervisor.IsHypervisor() {
-			return fmt.Errorf("Node %s is not a hypervisor; cannot start a VM on it", hypervisor.Name)
+			return fmt.Errorf("Node %s is not a hypervisor; cannot list VMs on it", hypervisor.Name)
 		}
 
 		list, err := esxi.ListVms(hypervisor.ConnectionString())

--- a/cmd/hope/vm/list.go
+++ b/cmd/hope/vm/list.go
@@ -1,0 +1,43 @@
+package vm
+
+import (
+	"fmt"
+)
+
+import (
+	"github.com/spf13/cobra"
+)
+
+import (
+	"github.com/Eagerod/hope/cmd/hope/utils"
+	"github.com/Eagerod/hope/pkg/esxi"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Lists VMs on the specified host.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		hypervisorName := args[0]
+
+		hypervisor, err := utils.GetNode(hypervisorName)
+		if err != nil {
+			return err
+		}
+
+		if !hypervisor.IsHypervisor() {
+			return fmt.Errorf("Node %s is not a hypervisor; cannot start a VM on it", hypervisor.Name)
+		}
+
+		list, err := esxi.ListVms(hypervisor.ConnectionString())
+		if err != nil {
+			return err
+		}
+
+		for _, l := range *list {
+			fmt.Println(l)
+		}
+
+		return err
+	},
+}

--- a/cmd/hope/vm/root.go
+++ b/cmd/hope/vm/root.go
@@ -12,6 +12,7 @@ var RootCommand = &cobra.Command{
 
 func InitVMCommand() {
 	RootCommand.AddCommand(createCmd)
+	RootCommand.AddCommand(deleteCmd)
 	RootCommand.AddCommand(imageCmd)
 	RootCommand.AddCommand(ipCmd)
 	RootCommand.AddCommand(listCmd)

--- a/cmd/hope/vm/root.go
+++ b/cmd/hope/vm/root.go
@@ -14,6 +14,7 @@ func InitVMCommand() {
 	RootCommand.AddCommand(createCmd)
 	RootCommand.AddCommand(imageCmd)
 	RootCommand.AddCommand(ipCmd)
+	RootCommand.AddCommand(listCmd)
 	RootCommand.AddCommand(startCmd)
 	RootCommand.AddCommand(stopCmd)
 

--- a/pkg/esxi/esxi.go
+++ b/pkg/esxi/esxi.go
@@ -56,3 +56,21 @@ func GetIpAddressOfVmNamed(host string, vmName string) (string, error) {
 	ip := strings.TrimSpace(strings.Split(lines[1], ",")[0])
 	return ip, nil
 }
+
+func ListVms(host string) (*[]string, error) {
+	retVal := []string{}
+
+	output, err := ssh.GetSSH(host, "vim-cmd", "vmsvc/getallvms")
+	if err != nil {
+		return nil, err
+	}
+
+	// Line 0 is headers, so skip that.
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n")[1:] {
+		// Vmid Name File Guest_OS Version Annotation
+		fields := strings.Fields(line)
+		retVal = append(retVal, fields[1])
+	}
+	
+	return &retVal, nil
+}

--- a/pkg/esxi/esxi.go
+++ b/pkg/esxi/esxi.go
@@ -9,6 +9,9 @@ import (
 	"github.com/Eagerod/hope/pkg/ssh"
 )
 
+const VmStatePoweredOn string = "Powered on"
+const VmStatePoweredOff string = "Powered off"
+
 func PowerOnVm(host string, vmId string) error {
 	return ssh.ExecSSH(host, "vim-cmd", "vmsvc/power.on", vmId)
 }
@@ -71,6 +74,47 @@ func ListVms(host string) (*[]string, error) {
 		fields := strings.Fields(line)
 		retVal = append(retVal, fields[1])
 	}
-	
+
 	return &retVal, nil
+}
+
+func DeleteVm(host string, vmId string) error {
+	return ssh.ExecSSH(host, "vim-cmd", "vmsvc/destroy", vmId)
+}
+
+func DeleteVmNamed(host string, vmName string) error {
+	vmId, err := idFromName(host, vmName)
+	if err != nil {
+		return err
+	}
+
+	return DeleteVm(host, vmId)
+}
+
+func PowerStateOfVm(host string, vmId string) (string, error) {
+	output, err := ssh.GetSSH(host, "vim-cmd", "vmsvc/power.getstate", vmId)
+	if err != nil {
+		return "", err
+	}
+
+	outputLines := strings.Split(output, "\n")
+	if len(outputLines) < 2 {
+		return "", fmt.Errorf("Failed to parse power state from: %s", output)
+	}
+
+	switch outputLines[1] {
+	case VmStatePoweredOff, VmStatePoweredOn:
+		return outputLines[1], nil
+	}
+
+	return "", fmt.Errorf("Unknown power state: %s", output)
+}
+
+func PowerStateOfVmNamed(host string, vmName string) (string, error) {
+	vmId, err := idFromName(host, vmName)
+	if err != nil {
+		return "", err
+	}
+
+	return PowerStateOfVm(host, vmId)
 }


### PR DESCRIPTION
v0.15.0 broke a bunch of stuff, so to start fixing it, adds a few methods to make full stack testing possible.

This enables a future test job to create VM images, start vms, and then eventually tear them down and delete them without needing extra manual intervention, as long as SSH is set up with the hypervisors correctly.