### PR TITLE
Use vim-cmd to get IP Address information if available.

### DIFF
--- a/pkg/esxi/vim_cmd_parser.go
+++ b/pkg/esxi/vim_cmd_parser.go
@@ -1,0 +1,43 @@
+package esxi
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Super sketchy function that attempts to convert the vim-cmd structured
+//  output into a JSON-looking string.
+// From there, it can be fed into json.Unmarshal.
+func VimCmdParseOutput(input string) string {
+	outputLines := []string{}
+	inputLines := strings.Split(input, "\n")
+
+	typeNameAfterKeyRegex := regexp.MustCompile("^(\\s*\\w+) = \\([^\\)]+\\)")
+	typeNameNoKeyRegex := regexp.MustCompile("^\\s*\\([^\\)]+\\)")
+	keyNameRegex := regexp.MustCompile("^(\\s+)(\\w+) =")
+
+	outputStarted := false
+	for _, l := range inputLines {
+		// Some command outputs start with a descriptive line, some don't, so
+		//   try to find the first actual line out of output before appending
+		//   to the output.
+		// Actual output always seems to start with a type name in ().
+		if !outputStarted {
+			if strings.HasPrefix(l, "(") {
+				outputStarted = true
+			} else {
+				continue
+			}
+		}
+
+		// Remove type names from the output.
+		l = typeNameAfterKeyRegex.ReplaceAllString(l, "$1 = ")
+		l = typeNameNoKeyRegex.ReplaceAllString(l, "")
+		l = keyNameRegex.ReplaceAllString(l, "$1\"$2\":")
+		l = strings.Replace(l, " <unset>", " null", 1)
+
+		outputLines = append(outputLines, l)
+	}
+
+	return strings.Join(outputLines, "\n")
+}

--- a/pkg/esxi/vim_cmd_parser_test.go
+++ b/pkg/esxi/vim_cmd_parser_test.go
@@ -1,0 +1,67 @@
+package esxi
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+// Lots of stuff omitted from here.
+const testString string = `Guest information:
+
+(vim.vm.GuestInfo) {
+   toolsStatus = "toolsOk", 
+   toolsVersionStatus = "guestToolsUnmanaged", 
+   toolsVersionStatus2 = "guestToolsUnmanaged", 
+   toolsRunningStatus = "guestToolsRunning", 
+   toolsVersion = "11333", 
+   toolsInstallType = "guestToolsTypeOpenVMTools", 
+   toolsUpdateStatus = (vim.vm.GuestInfo.ToolsUpdateStatus) null, 
+   guestId = "debian10_64Guest", 
+   guestFamily = "linuxGuest", 
+   guestFullName = "Debian GNU/Linux 10 (64-bit)", 
+   hostName = "debian", 
+   ipAddress = "192.168.200.9", 
+   net = (vim.vm.GuestInfo.NicInfo) [
+      (vim.vm.GuestInfo.NicInfo) {
+         network = "Kubernetes Network", 
+         ipAddress = (string) [
+            "192.168.200.9", 
+            "fe80::20c:29ff:fe62:e86d"
+         ], 
+         macAddress = "00:0c:29:62:e8:6d"
+      }
+   ], 
+   screen = (vim.vm.GuestInfo.ScreenInfo) {
+      width = 800, 
+      height = 600
+   }, 
+   guestState = "running"
+}
+`
+
+type desiredRetVal struct {
+	GuestFullName string `json:"guestFullName"`
+	IpAddress string `json:"ipAddress"`
+	Net []struct {
+		IpAddress []string `json:"ipAddress"`
+	} `json:"net"`
+}
+
+func TestVimCmdParseOutput(t *testing.T) {
+	o := VimCmdParseOutput(testString)
+
+	fmt.Println(o)
+
+	var retVal desiredRetVal
+	err := json.Unmarshal([]byte(o), &retVal)
+	assert.Nil(t, err)
+	
+	assert.Equal(t, retVal.GuestFullName, "Debian GNU/Linux 10 (64-bit)")
+	assert.Equal(t, retVal.IpAddress, "192.168.200.9")
+	assert.Equal(t, retVal.Net[0].IpAddress[0], "192.168.200.9")
+}


### PR DESCRIPTION
If a guest has Guest OS Tools installed on it, get the IP address reported by that, rather than using `esxcli`. 