### PR TITLE
Updates node list to be able to output based on a go-template

### DIFF
--- a/cmd/hope/node/list.go
+++ b/cmd/hope/node/list.go
@@ -1,7 +1,8 @@
 package node
 
 import (
-	"fmt"
+	"text/template"
+	"os"
 )
 
 import (
@@ -14,9 +15,11 @@ import (
 )
 
 var listCmdTypeSlice *[]string
+var listCmdTemplate *string
 
 func initListCmd() {
 	listCmdTypeSlice = listCmd.Flags().StringArrayP("type", "t", []string{}, "list nodes of this type")
+	listCmdTemplate = listCmd.Flags().StringP("template", "", "{{.Name}}\n", "Format the output using this go-template")
 }
 
 var listCmd = &cobra.Command{
@@ -33,13 +36,18 @@ var listCmd = &cobra.Command{
 			}
 		}
 
-		nodeNames, err := utils.GetNodeNames(*listCmdTypeSlice)
+		nodeNames, err := utils.GetBareNodeTypes(*listCmdTypeSlice)
+		if err != nil {
+			return err
+		}
+
+		tmpl, err := template.New("").Parse(*listCmdTemplate)
 		if err != nil {
 			return err
 		}
 
 		for _, node := range nodeNames {
-			fmt.Println(node)
+			tmpl.Execute(os.Stdout, node)
 		}
 
 		return nil

--- a/cmd/hope/node/list.go
+++ b/cmd/hope/node/list.go
@@ -41,7 +41,7 @@ var listCmd = &cobra.Command{
 			return err
 		}
 
-		tmpl, err := template.New("").Parse(*listCmdTemplate)
+		tmpl, err := template.New("list-command-template").Parse(*listCmdTemplate)
 		if err != nil {
 			return err
 		}

--- a/cmd/hope/utils/nodes.go
+++ b/cmd/hope/utils/nodes.go
@@ -34,24 +34,17 @@ func getNodes() ([]hope.Node, error) {
 }
 
 func GetNodeNames(types []string) ([]string, error) {
-	typesMap := map[string]bool{}
-	for _, t := range types {
-		typesMap[t] = true
-	}
-
-	nodes, err := getNodes()
+	nodes, err := GetBareNodeTypes(types)
 	if err != nil {
 		return nil, err
 	}
 
-	nodeNames := make([]string, 0, len(nodes))
+	rv := make([]string, 0, len(nodes))
 	for _, node := range nodes {
-		if _, ok := typesMap[node.Role]; ok {
-			nodeNames = append(nodeNames, node.Name)
-		}
+		rv = append(rv, node.Name)
 	}
 
-	return nodeNames, nil
+	return rv, nil
 }
 
 func GetNode(name string) (hope.Node, error) {
@@ -76,6 +69,27 @@ func GetBareNode(name string) (hope.Node, error) {
 	}
 
 	return hope.Node{}, fmt.Errorf("Failed to find a node named %s", name)
+}
+
+func GetBareNodeTypes(types []string) ([]hope.Node, error) {
+	nodes, err := getNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	typesMap := map[string]bool{}
+	for _, t := range types {
+		typesMap[t] = true
+	}
+
+	rv := make([]hope.Node, 0, len(nodes))
+	for _, node := range nodes {
+		if _, ok := typesMap[node.Role]; ok {
+			rv = append(rv, node)
+		}
+	}
+
+	return rv, nil
 }
 
 // HasNode -- Check whether a node has been defined in the hope file, even if


### PR DESCRIPTION
Allows operators to pull values out of nodes while iterating over them, so different operations can be done. 

Specific example that warranted created this -- iterating over the node list, and being able to check the node's hypervisor for the node's state if Kubernetes doesn't have knowledge of the node.