### PR TITLE
Adds the ability to create ConfigMaps from files

### DIFF
--- a/cmd/hope/deploy.go
+++ b/cmd/hope/deploy.go
@@ -100,7 +100,7 @@ var deployCmd = &cobra.Command{
 				return err
 			}
 
-			parameters, err := utils.RenderParameters(resource.Parameters, resource.FileParameters)
+			parameters, err := utils.FlattenParameters(resource.Parameters, resource.FileParameters)
 			if err != nil {
 				return err
 			}

--- a/cmd/hope/deploy.go
+++ b/cmd/hope/deploy.go
@@ -100,14 +100,19 @@ var deployCmd = &cobra.Command{
 				return err
 			}
 
+			parameters, err := utils.RenderParameters(resource.Parameters, resource.FileParameters)
+			if err != nil {
+				return err
+			}
+
 			switch resourceType {
 			case hope.ResourceTypeFile:
-				if len(resource.Parameters) != 0 {
+				if len(parameters) != 0 {
 					if info, err := os.Stat(resource.File); err != nil {
 						return err
 					} else if info.IsDir() {
 						log.Trace("Deploying directory with parameters; creating copy for parameter substitution.")
-						tempDir, err := hope.ReplaceParametersInDirectoryCopy(resource.File, resource.Parameters)
+						tempDir, err := hope.ReplaceParametersInDirectoryCopy(resource.File, parameters)
 						if err != nil {
 							return err
 						}
@@ -117,7 +122,7 @@ var deployCmd = &cobra.Command{
 							return err
 						}
 					} else {
-						content, err := hope.ReplaceParametersInFile(resource.File, resource.Parameters)
+						content, err := hope.ReplaceParametersInFile(resource.File, parameters)
 						if err != nil {
 							return err
 						}
@@ -139,8 +144,8 @@ var deployCmd = &cobra.Command{
 				//   are likely being populated.
 				log.Trace(inline)
 
-				if len(resource.Parameters) != 0 {
-					inline, err = hope.ReplaceParametersInString(inline, resource.Parameters)
+				if len(parameters) != 0 {
+					inline, err = hope.ReplaceParametersInString(inline, parameters)
 					if err != nil {
 						return err
 					}

--- a/cmd/hope/remove.go
+++ b/cmd/hope/remove.go
@@ -57,7 +57,7 @@ var removeCmd = &cobra.Command{
 				return err
 			}
 
-			parameters, err := utils.RenderParameters(resource.Parameters, resource.FileParameters)
+			parameters, err := utils.FlattenParameters(resource.Parameters, resource.FileParameters)
 			if err != nil {
 				return err
 			}

--- a/cmd/hope/remove.go
+++ b/cmd/hope/remove.go
@@ -56,13 +56,18 @@ var removeCmd = &cobra.Command{
 				return err
 			}
 
+			parameters, err := utils.RenderParameters(resource.Parameters, resource.FileParameters)
+			if err != nil {
+				return err
+			}
+
 			// It is possible that names of resources are created using
 			//   templated values, so still do the environment substitution
 			//   process.
 			switch resourceType {
 			case hope.ResourceTypeFile:
-				if len(resource.Parameters) != 0 {
-					content, err := hope.ReplaceParametersInFile(resource.File, resource.Parameters)
+				if len(parameters) != 0 {
+					content, err := hope.ReplaceParametersInFile(resource.File, parameters)
 					if err != nil {
 						return err
 					}
@@ -83,8 +88,8 @@ var removeCmd = &cobra.Command{
 				//   are likely being populated.
 				log.Trace(inline)
 
-				if len(resource.Parameters) != 0 {
-					inline, err = hope.ReplaceParametersInString(inline, resource.Parameters)
+				if len(parameters) != 0 {
+					inline, err = hope.ReplaceParametersInString(inline, parameters)
 					if err != nil {
 						return err
 					}

--- a/cmd/hope/utils/resources.go
+++ b/cmd/hope/utils/resources.go
@@ -78,6 +78,8 @@ func GetIdentifiableResources(names *[]string, tags *[]string) (*[]hope.Resource
 
 // For each parameter from a file, load the file and populate the base64
 //   values of the files into the properties.
+// Does nothing to deduplicate keys.
+// All plain parameters will exist in the list before file parameters.
 func RenderParameters(directParameters, fileParameters []string) ([]string, error) {
 	rv := directParameters
 

--- a/cmd/hope/utils/resources.go
+++ b/cmd/hope/utils/resources.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -94,13 +93,13 @@ func RenderParameters(directParameters, fileParameters []string) ([]string, erro
 			return nil, fmt.Errorf("cannot resolve parameter contents from directory: %s", paramPath)
 		}
 
-		srcFile, err := ioutil.ReadFile(paramPath)
+		contents, err := hope.ReplaceParametersInFile(paramPath, directParameters)
 		if err != nil {
 			return nil, err
 		}
 
 		log.Tracef("Writing base64ed contents of file %s to parameter %s", paramPath, paramName)
-		b64Content := base64.StdEncoding.EncodeToString(srcFile)
+		b64Content := base64.StdEncoding.EncodeToString([]byte(contents))
 
 		expandedParam := fmt.Sprintf("%s=%s", paramName, b64Content)
 		rv = append(rv, expandedParam)

--- a/cmd/hope/utils/resources.go
+++ b/cmd/hope/utils/resources.go
@@ -79,7 +79,7 @@ func GetIdentifiableResources(names *[]string, tags *[]string) (*[]hope.Resource
 //   values of the files into the properties.
 // Does nothing to deduplicate keys.
 // All plain parameters will exist in the list before file parameters.
-func RenderParameters(directParameters, fileParameters []string) ([]string, error) {
+func FlattenParameters(directParameters, fileParameters []string) ([]string, error) {
 	rv := directParameters
 
 	for _, param := range fileParameters {

--- a/cmd/hope/utils/resources_test.go
+++ b/cmd/hope/utils/resources_test.go
@@ -111,3 +111,24 @@ func TestGetIdentifiableResources(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderParameters(t *testing.T) {
+	var tests = []struct {
+		name       string
+		params     []string
+		fileParams []string
+		expected   []string
+	}{
+		{"Nothing", []string{}, []string{}, []string{}},
+		{"Only param", []string{"A=B"}, []string{}, []string{"A=B"}},
+		{"Only file", []string{}, []string{"A=../../../test/small"}, []string{"A=Q29udGVudAo="}},
+		{"Both", []string{"A=B"}, []string{"B=../../../test/small"}, []string{"A=B", "B=Q29udGVudAo="}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parameters, err := RenderParameters(tt.params, tt.fileParams)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expected, parameters)
+		})
+	}
+}

--- a/cmd/hope/utils/resources_test.go
+++ b/cmd/hope/utils/resources_test.go
@@ -131,6 +131,7 @@ func TestRenderParameters(t *testing.T) {
 		{"Only file", []string{}, []string{"A=../../../test/small"}, []string{"A=Q29udGVudAo="}},
 		{"Both", []string{"A=B"}, []string{"B=../../../test/small"}, []string{"A=B", "B=Q29udGVudAo="}},
 		{"Duplicate Keys", []string{"A=B"}, []string{"A=../../../test/small"}, []string{"A=B", "A=Q29udGVudAo="}},
+		{"Recursive Substitution", []string{"WORLD=Hope"}, []string{"A=../../../test/small-recursive"}, []string{"WORLD=Hope", "A=SGVsbG8sIEhvcGUhCg=="}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -139,4 +140,9 @@ func TestRenderParameters(t *testing.T) {
 			assert.Equal(t, tt.expected, parameters)
 		})
 	}
+}
+
+func TestRenderParametersSelfReferential(t *testing.T) {
+	_, err := RenderParameters([]string{"WORLD"}, []string{"WORLD=../../../test/small", "A=../../../test/small-recursive"})
+	assert.Equal(t, "Failed to find WORLD in environment.", err.Error())
 }

--- a/cmd/hope/utils/resources_test.go
+++ b/cmd/hope/utils/resources_test.go
@@ -63,6 +63,13 @@ var testResources []hope.Resource = []hope.Resource{
 		},
 		Tags: []string{"database"},
 	},
+	{
+		Name: "configmap-with-file-keys",
+		Inline: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: file-keys\nbinaryData:\n  script.sh: ${SCRIPT_SH_FILE}\ndata:\n  something_else: ${SOME_OTHER_KEY}\n",
+		Parameters: []string{"SOME_OTHER_KEY=abc"},
+		FileParameters: []string{"SCRIPT_SH_FILE=test/script.sh"},
+		Tags: []string{"another-tag"},
+	},
 }
 
 // Basically a smoke test, don't want to define a ton of yaml blocks to test
@@ -123,6 +130,7 @@ func TestRenderParameters(t *testing.T) {
 		{"Only param", []string{"A=B"}, []string{}, []string{"A=B"}},
 		{"Only file", []string{}, []string{"A=../../../test/small"}, []string{"A=Q29udGVudAo="}},
 		{"Both", []string{"A=B"}, []string{"B=../../../test/small"}, []string{"A=B", "B=Q29udGVudAo="}},
+		{"Duplicate Keys", []string{"A=B"}, []string{"A=../../../test/small"}, []string{"A=B", "A=Q29udGVudAo="}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/hope/utils/resources_test.go
+++ b/cmd/hope/utils/resources_test.go
@@ -143,6 +143,27 @@ func TestFlattenParameters(t *testing.T) {
 }
 
 func TestFlattenParametersSelfReferential(t *testing.T) {
-	_, err := FlattenParameters([]string{"WORLD"}, []string{"WORLD=../../../test/small", "A=../../../test/small-recursive"})
+	params, err := FlattenParameters([]string{"WORLD"}, []string{"WORLD=../../../test/small", "A=../../../test/small-recursive"})
 	assert.Equal(t, "Failed to find WORLD in environment.", err.Error())
+	assert.Nil(t, params)
+}
+
+func TestFlattenParametersIncomplete(t *testing.T) {
+	params, err := FlattenParameters([]string{}, []string{""})
+	assert.Equal(t, "file parameter must be in the form PARAM=<file path>", err.Error())
+	assert.Nil(t, params)
+
+	params, err = FlattenParameters([]string{}, []string{"WORLD"})
+	assert.Equal(t, "file parameter WORLD must provide file path", err.Error())
+	assert.Nil(t, params)
+
+	params, err = FlattenParameters([]string{}, []string{"=test/small"})
+	assert.Equal(t, "file parameter must include a name", err.Error())
+	assert.Nil(t, params)
+}
+
+func TestFlattenParametersDirectory(t *testing.T) {
+	params, err := FlattenParameters([]string{}, []string{"A=../../../test"})
+	assert.Equal(t, "cannot resolve parameter A contents from directory: ../../../test", err.Error())
+	assert.Nil(t, params)
 }

--- a/cmd/hope/utils/resources_test.go
+++ b/cmd/hope/utils/resources_test.go
@@ -119,7 +119,7 @@ func TestGetIdentifiableResources(t *testing.T) {
 	}
 }
 
-func TestRenderParameters(t *testing.T) {
+func TestFlattenParameters(t *testing.T) {
 	var tests = []struct {
 		name       string
 		params     []string
@@ -135,14 +135,14 @@ func TestRenderParameters(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parameters, err := RenderParameters(tt.params, tt.fileParams)
+			parameters, err := FlattenParameters(tt.params, tt.fileParams)
 			assert.Nil(t, err)
 			assert.Equal(t, tt.expected, parameters)
 		})
 	}
 }
 
-func TestRenderParametersSelfReferential(t *testing.T) {
-	_, err := RenderParameters([]string{"WORLD"}, []string{"WORLD=../../../test/small", "A=../../../test/small-recursive"})
+func TestFlattenParametersSelfReferential(t *testing.T) {
+	_, err := FlattenParameters([]string{"WORLD"}, []string{"WORLD=../../../test/small", "A=../../../test/small-recursive"})
 	assert.Equal(t, "Failed to find WORLD in environment.", err.Error())
 }

--- a/hope.yaml
+++ b/hope.yaml
@@ -181,6 +181,25 @@ resources:
         - -e
         - select * from abc;
     tags: [database]
+  # Sometimes, ConfigMaps contain keys that are really not fun to embed in a
+  #   yaml file using multi-line strings
+  # This parameter substitution mechanism lets you pull base64 data out of a
+  #   file.
+  - name: configmap-with-file-keys
+    inline: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: file-keys
+      binaryData:
+        script.sh: ${SCRIPT_SH_FILE}
+      data:
+        something_else: ${SOME_OTHER_KEY}
+    parameters:
+      - SOME_OTHER_KEY=abc
+    fileParameters:
+      - SCRIPT_SH_FILE=test/script.sh
+    tags: [another-tag]
 # Jobs contains a collection of specifications of templated jobs that can be
 #   run on demand in the cluster.
 # These jobs shouldn't be associated to the deployment of any particular

--- a/pkg/hope/entities.go
+++ b/pkg/hope/entities.go
@@ -92,14 +92,15 @@ type ExecSpec struct {
 // There may be a better way of doing this, but with a pretty generic list of
 //   items appearing in a yaml file, maybe not.
 type Resource struct {
-	Name       string
-	File       string
-	Inline     string
-	Parameters []string
-	Build      BuildSpec
-	Job        string
-	Exec       ExecSpec
-	Tags       []string
+	Name           string
+	File           string
+	Inline         string
+	Parameters     []string
+	FileParameters []string
+	Build          BuildSpec
+	Job            string
+	Exec           ExecSpec
+	Tags           []string
 }
 
 // Job - Properties that can appear in any ephemeral job definition.

--- a/test/script.sh
+++ b/test/script.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+#
+echo >&2 "I'm a cool script, and I'm going to do something useful."
+
+sleep 10
+
+echo >&2 "Still working on that thing boss."
+
+sleep 10
+
+echo >&2 "Lol jk, I'm actually just a test file."

--- a/test/small
+++ b/test/small
@@ -1,0 +1,1 @@
+Content

--- a/test/small-recursive
+++ b/test/small-recursive
@@ -1,0 +1,1 @@
+Hello, ${WORLD}!


### PR DESCRIPTION
Resolves #27.

Introduces the ability to load base64 data out from files for them to be applied to ConfigMaps/Secrets/anything really (as long as it accepts base64'ed data.

Does need to be used with `binaryData`, which was introduced in Kubernetes 1.10, but I'm not really being too strict about versions with this tool, so it doesn't seem that crazy to make it a requirement to use this feature.