### PR TITLE
Improves load balancer update handling

### DIFF
--- a/pkg/hope/load_balancer.go
+++ b/pkg/hope/load_balancer.go
@@ -2,7 +2,6 @@ package hope
 
 import (
 	"fmt"
-	"path"
 	"strings"
 )
 
@@ -46,7 +45,6 @@ func SetLoadBalancerHosts(log *logrus.Entry, node *Node, masters *[]Node) error 
 	//   to write it out directly in a set of statements, copy the file into
 	//   the authenticated user's home directory, then copy with root to where
 	//   nginx wants it.
-	// Pretty sketchy building up the path in the way it is.
 	connectionString := node.ConnectionString()
 	configTempFilename := uuid.New().String()
 	dest := fmt.Sprintf("%s:%s", connectionString, configTempFilename)
@@ -54,20 +52,34 @@ func SetLoadBalancerHosts(log *logrus.Entry, node *Node, masters *[]Node) error 
 		return err
 	}
 
-	output, err := ssh.GetSSH(connectionString, "pwd")
+	// Check to see if a container is already running.
+	// If one is, lots of steps have already been done already, and can just
+	//   update the configuration in the already-running container.
+	// If not, will have to do some work to get the container up.
+	runningContainer, err := ssh.GetSSH(connectionString, "sudo", "docker", "ps", "-f", "expose=6443", "-q")
 	if err != nil {
 		return err
 	}
 
-	configTempPath := path.Join(strings.TrimSpace(output), configTempFilename)
+	runningContainer = strings.TrimSpace(runningContainer)
 
 	// TODO: Parameterize nginx version?
-	statements := []string{
-		"mkdir -p /etc/nginx",
-		fmt.Sprintf("mv %s /etc/nginx/nginx.conf", configTempPath),
-		"chown root:root /etc/nginx/nginx.conf",
-		"docker kill $(docker ps -f expose=6443 -q) || true",
-		"docker run -d -v /etc/nginx/nginx.conf:/etc/nginx/nginx.conf -p 6443:6443 --restart unless-stopped nginx:1.19.4",
+	var statements []string
+	if runningContainer == "" {
+		statements = []string{
+			"mkdir -p /etc/nginx",
+			fmt.Sprintf("mv %s /etc/nginx/nginx.conf", configTempFilename),
+			"chown root:root /etc/nginx/nginx.conf",
+			"docker run -d -v /etc/nginx/nginx.conf:/etc/nginx/nginx.conf -p 6443:6443 --restart unless-stopped nginx:1.19.4",
+		}
+	} else {
+		// Volume needs to keep the same inode, so have to trunc
+		//   and append.
+		statements = []string{
+			fmt.Sprintf("cat %s > /etc/nginx/nginx.conf", configTempFilename),
+			fmt.Sprintf("docker exec -i %s nginx -s reload", runningContainer),
+			fmt.Sprintf("rm %s", configTempFilename),
+		}
 	}
 
 	script := fmt.Sprintf("'%s'", strings.Join(statements, ";\n"))

--- a/pkg/hope/load_balancer.go
+++ b/pkg/hope/load_balancer.go
@@ -48,10 +48,6 @@ func SetLoadBalancerHosts(log *logrus.Entry, node *Node, masters *[]Node) error 
 		return err
 	}
 
-	// Check to see if a container is already running.
-	// If one is, lots of steps have already been done already, and can just
-	//   update the configuration in the already-running container.
-	// If not, will have to do some work to get the container up.
 	runningContainer, err := ssh.GetSSH(connectionString, "sudo", "docker", "ps", "-f", "expose=6443", "-q")
 	if err != nil {
 		return err
@@ -60,6 +56,8 @@ func SetLoadBalancerHosts(log *logrus.Entry, node *Node, masters *[]Node) error 
 	runningContainer = strings.TrimSpace(runningContainer)
 
 	// TODO: Parameterize nginx version?
+	// If a container is already running, just update its config.
+	// If not, create the initial config + create the container.
 	var statements []string
 	if runningContainer == "" {
 		statements = []string{

--- a/pkg/hope/resources.go
+++ b/pkg/hope/resources.go
@@ -38,8 +38,7 @@ stream {
                      '$protocol $status $bytes_sent $bytes_received '
                      '$session_time';
 
-    upstream backend {
-        %s
+    upstream backend {%s
     }
 
     server {


### PR DESCRIPTION
Right now, when a load balancer update is pushed, the `nginx.conf` file is swapped out on the host, and then the NGINX container is restarted. This updates the load balancer configuration process to run different procedures depending on whether or not NGINX seems to already be running.

If NGINX isn't running, `nginx.conf` is created on the host, and the NGINX container is started pointing at that config file. 

If NGINX is running, replaces the content of `nginx.conf` on the host, and send NGINX the reload signal.

This should result in less disruptive load balancer updates, because long-running connections through it should be preserved following a reload, but would definitely be terminated with the whole container being thrown away.