### PR TITLE
Updates ssh-copy-id to proper argument order

### DIFF
--- a/pkg/hope/unix_config.go
+++ b/pkg/hope/unix_config.go
@@ -126,8 +126,12 @@ func TryConfigureSSH(log *logrus.Entry, node *Node) error {
 }
 
 func CopySSHKeyToAuthorizedKeys(log *logrus.Entry, node *Node) error {
-	connectionString := node.ConnectionString()
-	osCmd := exec.Command("ssh-copy-id", connectionString, "-o", "StrictHostKeyChecking=no")
+	args := []string{
+		"-o", "StrictHostKeyChecking=no",
+		node.ConnectionString(),
+	}
+	log.Debug("ssh-copy-id ", strings.Join(args, " "))
+	osCmd := exec.Command("ssh-copy-id", args...)
 	osCmd.Stdin = os.Stdin
 	osCmd.Stdout = os.Stdout
 	osCmd.Stderr = os.Stderr


### PR DESCRIPTION
Reorders ssh-copy-id command's arguments to be in the correct order. 

Adds a log statement so its execution can be reviewed similar to other subprocess events. 