### PR TITLE
Updates load balancer init process to initialize with hosts

### DIFF
--- a/cmd/hope/node/init.go
+++ b/cmd/hope/node/init.go
@@ -56,8 +56,8 @@ var initCmd = &cobra.Command{
 		}
 
 		var lbp *hope.Node = nil
-		if loadBalancer != (hope.Node{}){
-			lbp =  &loadBalancer
+		if loadBalancer != (hope.Node{}) {
+			lbp = &loadBalancer
 		}
 		loadBalancerHost := viper.GetString("load_balancer_host")
 

--- a/cmd/hope/node/init.go
+++ b/cmd/hope/node/init.go
@@ -49,12 +49,17 @@ var initCmd = &cobra.Command{
 		if err != nil && loadBalancer != (hope.Node{}) {
 			return err
 		}
+
+		var lbp *hope.Node = nil
+		if loadBalancer != (hope.Node{}){
+			lbp =  &loadBalancer
+		}
 		loadBalancerHost := viper.GetString("load_balancer_host")
 
 		if node.IsMasterAndNode() {
 			log.Info("Node ", node.Host, " appears to be both master and node. Creating master and removing NoSchedule taint...")
 
-			if err := hope.CreateClusterMaster(log.WithFields(log.Fields{}), &node, podNetworkCidr, &loadBalancer, loadBalancerHost, &masters, initCmdForce); err != nil {
+			if err := hope.CreateClusterMaster(log.WithFields(log.Fields{}), &node, podNetworkCidr, lbp, loadBalancerHost, &masters, initCmdForce); err != nil {
 				return err
 			}
 
@@ -67,7 +72,7 @@ var initCmd = &cobra.Command{
 
 			return hope.TaintNodeByHost(kubectl, &node, "node-role.kubernetes.io/master:NoSchedule-")
 		} else if node.IsMaster() {
-			return hope.CreateClusterMaster(log.WithFields(log.Fields{}), &node, podNetworkCidr, &loadBalancer, loadBalancerHost, &masters, initCmdForce)
+			return hope.CreateClusterMaster(log.WithFields(log.Fields{}), &node, podNetworkCidr, lbp, loadBalancerHost, &masters, initCmdForce)
 		} else if node.IsNode() {
 			return hope.CreateClusterNode(log.WithFields(log.Fields{}), &node, &masters, initCmdForce)
 		} else {

--- a/cmd/hope/node/init.go
+++ b/cmd/hope/node/init.go
@@ -36,7 +36,12 @@ var initCmd = &cobra.Command{
 		// Load balancer have a super lightweight init, so run its init before
 		//   fetching some potentially heavier state from the cluster.
 		if node.IsLoadBalancer() {
-			return hope.InitLoadBalancer(log.WithFields(log.Fields{}), &node)
+			masters, err := utils.GetAvailableMasters()
+			if err != nil {
+				return err
+			}
+
+			return hope.InitLoadBalancer(log.WithFields(log.Fields{}), &node, &masters)
 		}
 
 		podNetworkCidr := viper.GetString("pod_network_cidr")

--- a/pkg/hope/load_balancer.go
+++ b/pkg/hope/load_balancer.go
@@ -17,9 +17,9 @@ import (
 
 // Just forwards to `SetLoadBalancerHosts`.
 // There may be a time where this does more.
-func InitLoadBalancer(log *logrus.Entry, node *Node) error {
+func InitLoadBalancer(log *logrus.Entry, node *Node, masters *[]Node) error {
 	log.Debug("Starting to bootstrap a simple NGINX load balancer for API Servers at ", node.Host)
-	return SetLoadBalancerHosts(log, node, &[]Node{})
+	return SetLoadBalancerHosts(log, node, masters)
 }
 
 func SetLoadBalancerHosts(log *logrus.Entry, node *Node, masters *[]Node) error {

--- a/pkg/hope/load_balancer.go
+++ b/pkg/hope/load_balancer.go
@@ -37,9 +37,12 @@ func SetLoadBalancerHosts(log *logrus.Entry, node *Node, masters *[]Node) error 
 	if len(*masters) == 0 {
 		masterUpstreamContents = "server 0.0.0.0:6443;"
 	} else {
+		masterIps := []string{}
 		for _, master := range *masters {
 			masterUpstreamContents = fmt.Sprintf("%s\n        server %s:6443;", masterUpstreamContents, master.Host)
+			masterIps = append(masterIps, fmt.Sprintf("%s:6443", master.Host))
 		}
+		log.Infof("Setting load balancer upstreams to: %s", strings.Join(masterIps, ", "))
 	}
 	populatedConfig := fmt.Sprintf(NginxConfig, masterUpstreamContents)
 	configTempFilename := uuid.New().String()

--- a/pkg/hope/load_balancer.go
+++ b/pkg/hope/load_balancer.go
@@ -22,6 +22,25 @@ func InitLoadBalancer(log *logrus.Entry, node *Node, masters *[]Node) error {
 	return SetLoadBalancerHosts(log, node, masters)
 }
 
+// Build the nginx.conf file contents setting the given nodes as upstreams.
+func loadBalancerConfigurationFile(log *logrus.Entry, upstreams *[]Node) string {
+	// In the case where there are no masters yet, send traffic to a black
+	//   hole.
+	// Prevents Nginx from crash looping; upstream servers need at least one
+	masterUpstreamContents := ""
+	if len(*upstreams) == 0 {
+		masterUpstreamContents = "server 0.0.0.0:6443;"
+	} else {
+		masterIps := []string{}
+		for _, master := range *upstreams {
+			masterUpstreamContents = fmt.Sprintf("%s\n        server %s:6443;", masterUpstreamContents, master.Host)
+			masterIps = append(masterIps, fmt.Sprintf("%s:6443", master.Host))
+		}
+		log.Infof("Setting load balancer upstreams to: %s", strings.Join(masterIps, ", "))
+	}
+	return fmt.Sprintf(NginxConfig, masterUpstreamContents)
+}
+
 func SetLoadBalancerHosts(log *logrus.Entry, node *Node, masters *[]Node) error {
 	if len(*masters) == 0 {
 		log.Warn("Setting empty load balancer hosts.")
@@ -29,22 +48,7 @@ func SetLoadBalancerHosts(log *logrus.Entry, node *Node, masters *[]Node) error 
 
 	connectionString := node.ConnectionString()
 
-	// In the case where there are no masters yet, send traffic to a black
-	//   hole.
-	// Prevents Nginx from crash looping; upstream servers need at least one
-	//   endpoint.
-	masterUpstreamContents := ""
-	if len(*masters) == 0 {
-		masterUpstreamContents = "server 0.0.0.0:6443;"
-	} else {
-		masterIps := []string{}
-		for _, master := range *masters {
-			masterUpstreamContents = fmt.Sprintf("%s\n        server %s:6443;", masterUpstreamContents, master.Host)
-			masterIps = append(masterIps, fmt.Sprintf("%s:6443", master.Host))
-		}
-		log.Infof("Setting load balancer upstreams to: %s", strings.Join(masterIps, ", "))
-	}
-	populatedConfig := fmt.Sprintf(NginxConfig, masterUpstreamContents)
+	populatedConfig := loadBalancerConfigurationFile(log, masters)
 	configTempFilename := uuid.New().String()
 	dest := fmt.Sprintf("%s:%s", connectionString, configTempFilename)
 	if err := scp.ExecSCPBytes([]byte(populatedConfig), dest); err != nil {

--- a/pkg/hope/load_balancer_test.go
+++ b/pkg/hope/load_balancer_test.go
@@ -1,0 +1,24 @@
+package hope
+
+import (
+	"testing"
+)
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadBalancerConfigurationFileNoMasters(t *testing.T) {
+	masters := []Node{}
+	config := loadBalancerConfigurationFile(log.WithFields(log.Fields{}), &masters)
+	assert.Contains(t, config, "0.0.0.0:6443")
+}
+
+func TestLoadBalancerConfigurationFileMasters(t *testing.T) {
+	masters := []Node{
+		Node { Host: "192.168.1.254" },
+	}
+	config := loadBalancerConfigurationFile(log.WithFields(log.Fields{}), &masters)
+	assert.Contains(t, config, "192.168.1.254:6443")
+}

--- a/pkg/hope/load_balancer_test.go
+++ b/pkg/hope/load_balancer_test.go
@@ -17,7 +17,7 @@ func TestLoadBalancerConfigurationFileNoMasters(t *testing.T) {
 
 func TestLoadBalancerConfigurationFileMasters(t *testing.T) {
 	masters := []Node{
-		Node { Host: "192.168.1.254" },
+		Node{Host: "192.168.1.254"},
 	}
 	config := loadBalancerConfigurationFile(log.WithFields(log.Fields{}), &masters)
 	assert.Contains(t, config, "192.168.1.254:6443")


### PR DESCRIPTION
Updates the load balancer initialization process to start with available masters, rather than an empty set. 

Allows the load balancer to be repeatedly "re-inited" and still have the correct set of nodes in its upstreams, rather than having them get wiped. 

Fixes some of the chicken and egg problems when doing maintenance. 