### PR TITLE
Removes assumption of Docker on Kubernetes hosts

### DIFF
--- a/pkg/hope/node_management.go
+++ b/pkg/hope/node_management.go
@@ -17,6 +17,10 @@ import (
 	"github.com/Eagerod/hope/pkg/ssh"
 )
 
+// Sets up any configuration on Kubernetes nodes that are common between
+// control-plane nodes, and worker nodes.
+// TODO: Consider writing these files using file provisioners in Packer
+// instead?
 func setupCommonNodeRequirements(log *logrus.Entry, node *Node) error {
 	if !node.IsKubernetesNode() {
 		return fmt.Errorf("Node has role %s, should not prepare as Kubernetes node", node.Role)

--- a/pkg/hope/node_management.go
+++ b/pkg/hope/node_management.go
@@ -30,30 +30,6 @@ func setupCommonNodeRequirements(log *logrus.Entry, node *Node) error {
 
 	connectionString := node.ConnectionString()
 
-	// TODO: Create a function in ssh pkg that allows for running
-	//   multi-statement commands on the target without needing to manually
-	//   construct the string.
-	// TODO: Consider writing these files using file provisioners in Packer
-	//   instead?
-	commands := []string{
-		"mkdir -p /etc/sysconfig",
-		"echo \"\" > /etc/sysconfig/docker-storage",
-		"echo \"\" > /etc/sysconfig/docker-storage-setup",
-		fmt.Sprintf("echo \"%s\" > /etc/docker/daemon.json", strings.ReplaceAll(DockerDaemonJson, "\"", "\\\"")),
-		fmt.Sprintf("echo \"%s\" > /etc/sysctl.d/k8s.conf", K8SConf),
-		fmt.Sprintf("echo \"%s\" > /proc/sys/net/ipv4/ip_forward", IpForward),
-	}
-	commandString := fmt.Sprintf("'%s'", strings.Join(commands, " && "))
-
-	if err := ssh.ExecSSH(connectionString, "sudo", "sh", "-c", commandString); err != nil {
-		return err
-	}
-
-	// Various other setups.
-	if err := ssh.ExecSSH(connectionString, "sudo", "sed", "-i", "'/--exec-opt native.cgroupdriver/d'", "/usr/lib/systemd/system/docker.service"); err != nil {
-		return err
-	}
-
 	// Different versions of kubeabm will install their kubeadm.conf under
 	//   different paths; take the first one found from known paths.
 	possibleKubeadmConfigPaths := []string{
@@ -92,9 +68,7 @@ func setupCommonNodeRequirements(log *logrus.Entry, node *Node) error {
 	daemonsScript := fmt.Sprintf("\"%s\"", strings.Join(
 		[]string{
 			"systemctl daemon-reload",
-			"systemctl enable docker",
 			"systemctl enable kubelet",
-			"systemctl restart docker",
 			"systemctl restart kubelet",
 		},
 		" && ",

--- a/pkg/hope/resources.go
+++ b/pkg/hope/resources.go
@@ -15,13 +15,6 @@ var DockerDaemonJson = `{
 }
 `
 
-var K8SConf = `net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-`
-
-var IpForward = `1
-`
-
 var NginxConfig = `user  nginx;
 worker_processes  1;
 

--- a/pkg/hope/resources.go
+++ b/pkg/hope/resources.go
@@ -1,20 +1,5 @@
 package hope
 
-var DockerDaemonJson = `{
-    "exec-opts": [
-        "native.cgroupdriver=systemd"
-    ],
-    "log-driver": "json-file",
-    "log-opts": {
-        "max-size": "100m"
-    },
-    "storage-driver": "overlay2",
-    "storage-opts": [
-        "overlay2.override_kernel_check=true"
-    ]
-}
-`
-
 var NginxConfig = `user  nginx;
 worker_processes  1;
 


### PR DESCRIPTION
Creates the assumption that VM hosts have gotten their container runtime configured already.  

Is a little better baked for post Kubernetes 1.23.