### PR TITLE
Adds support for masters without hypervisors

### DIFF
--- a/cmd/hope/utils/nodes.go
+++ b/cmd/hope/utils/nodes.go
@@ -188,6 +188,12 @@ func GetAvailableMasters() ([]hope.Node, error) {
 
 	for _, node := range nodes {
 		if node.IsMaster() {
+			if node.Hypervisor == "" {
+				retVal = append(retVal, node)
+				continue
+			}
+
+			// Need to get more node details from hypervisor
 			hv, err := GetHypervisor(node.Hypervisor)
 			if err != nil {
 				return nil, err

--- a/cmd/hope/utils/nodes.go
+++ b/cmd/hope/utils/nodes.go
@@ -187,30 +187,32 @@ func GetAvailableMasters() ([]hope.Node, error) {
 	}
 
 	for _, node := range nodes {
-		if node.IsMaster() {
-			if node.Hypervisor == "" {
-				retVal = append(retVal, node)
-				continue
-			}
+		if !node.IsMaster() {
+			continue
+		}
 
-			// Need to get more node details from hypervisor
-			hv, err := GetHypervisor(node.Hypervisor)
+		if node.Hypervisor == "" {
+			retVal = append(retVal, node)
+			continue
+		}
+
+		// Need to get more node details from hypervisor
+		hv, err := GetHypervisor(node.Hypervisor)
+		if err != nil {
+			return nil, err
+		}
+
+		hvNodes, err := hv.ListNodes()
+		if err != nil {
+			return nil, err
+		}
+
+		if sliceutil.StringInSlice(node.Name, hvNodes) {
+			exNode, err := expandHypervisor(node)
 			if err != nil {
 				return nil, err
 			}
-
-			hvNodes, err := hv.ListNodes()
-			if err != nil {
-				return nil, err
-			}
-
-			if sliceutil.StringInSlice(node.Name, hvNodes) {
-				exNode, err := expandHypervisor(node)
-				if err != nil {
-					return nil, err
-				}
-				retVal = append(retVal, exNode)
-			}
+			retVal = append(retVal, exNode)
 		}
 	}
 

--- a/cmd/hope/utils/nodes_test.go
+++ b/cmd/hope/utils/nodes_test.go
@@ -59,8 +59,8 @@ var testNodes []hope.Node = []hope.Node{
 	{
 		Name:       "test-master-02",
 		Role:       hope.NodeRoleMaster.String(),
-		Hypervisor: "beast1",
 		User:       "packer",
+		Host:       "192.168.1.10",
 		Cpu:        2,
 		Memory:     2048,
 	},
@@ -278,8 +278,14 @@ func (s *NodesTestSuite) TestGetAvailableMasters() {
 
 	expectedOrig := testNodes[2:5]
 	expected := []hope.Node{}
+
 	for i, n := range expectedOrig {
-		n.Host = fmt.Sprintf("test-master-0%d", i+1)
+		if i == 1 {
+			n.Host = "192.168.1.10"
+		} else {
+			n.Host = fmt.Sprintf("test-master-0%d", i+1)
+		}
+
 		n.Hypervisor = ""
 		expected = append(expected, n)
 	}

--- a/hope.yaml
+++ b/hope.yaml
@@ -34,7 +34,7 @@ nodes:
     user: packer
   - name: test-master-02
     role: master
-    hypervisor: beast1
+    host: 192.168.1.10
     cpu: 2
     memory: 2048
     user: packer


### PR DESCRIPTION
Right now, a master without a hypervisor still tries to pull down hypervisor information, and errors out with no hypervisor found.

This fixes that, and bails early if there's no hypervisor to look up; returns the node as-is.