### PR TITLE
Fix fetching kubeadm join command from invalid masters

### DIFF
--- a/cmd/hope/utils/nodes_test.go
+++ b/cmd/hope/utils/nodes_test.go
@@ -57,12 +57,12 @@ var testNodes []hope.Node = []hope.Node{
 		Memory:     2048,
 	},
 	{
-		Name:       "test-master-02",
-		Role:       hope.NodeRoleMaster.String(),
-		User:       "packer",
-		Host:       "192.168.1.10",
-		Cpu:        2,
-		Memory:     2048,
+		Name:   "test-master-02",
+		Role:   hope.NodeRoleMaster.String(),
+		User:   "packer",
+		Host:   "192.168.1.10",
+		Cpu:    2,
+		Memory: 2048,
 	},
 	{
 		Name:       "test-master-03",

--- a/pkg/hope/node_management.go
+++ b/pkg/hope/node_management.go
@@ -154,7 +154,7 @@ func CreateClusterMaster(log *logrus.Entry, node *Node, podNetworkCidr string, l
 		return err
 	}
 
-	existingMasters := (*masters)[1:]
+	existingMasters := lbMasters[1:]
 	joinCommand, err := KubeadmGetClusterJoinCommandFromAnyMaster(&existingMasters)
 	if err != nil {
 		return err

--- a/pkg/hope/node_management_test.go
+++ b/pkg/hope/node_management_test.go
@@ -1,0 +1,18 @@
+package hope
+
+import (
+	"testing"
+)
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetupCommonNodeRequirementsNotKubernetesNode(t *testing.T) {
+	node := Node{
+		Role: "load-balancer",
+	}
+	err := setupCommonNodeRequirements(log.WithFields(log.Fields{}), &node)
+	assert.Error(t, err, "Node has role load-balancer, should not prepare as Kubernetes node")
+}


### PR DESCRIPTION
Right now, a node being initialized will try to ssh "into itself" to get the kubeadm join command that shouldn't work if it's the second master node in the list of defined nodes. 

Adds a basic test case for `node_management` just to get that started, but testing this deep into the already difficult to test function isn't going to be as trivial as fixing the issue. Another case of "this function does way too much remote stuff that's difficult to test"