### PR TITLE
Removes assumption that Hypervisors only have one struct property

### DIFF
--- a/cmd/hope/utils/nodes_test.go
+++ b/cmd/hope/utils/nodes_test.go
@@ -88,6 +88,10 @@ type MockHypervisor struct {
 	node hope.Node
 }
 
+func (m *MockHypervisor) Initialize(node hope.Node) error {
+	return nil
+}
+
 func (m *MockHypervisor) ListNodes() ([]string, error) {
 	nodes := []string{}
 	for _, n := range testNodes {

--- a/pkg/hope/hypervisors/exsi_hypervisor.go
+++ b/pkg/hope/hypervisors/exsi_hypervisor.go
@@ -19,7 +19,12 @@ type EsxiHypervisor struct {
 	node hope.Node
 }
 
-func (hyp EsxiHypervisor) ListNodes() ([]string, error) {
+func (hyp *EsxiHypervisor) Initialize(node hope.Node) error {
+	hyp.node = node
+	return nil
+}
+
+func (hyp *EsxiHypervisor) ListNodes() ([]string, error) {
 	v, e := esxi.ListVms(hyp.node.ConnectionString())
 	if e == nil {
 		return *v, nil

--- a/pkg/hope/hypervisors/hypervisor.go
+++ b/pkg/hope/hypervisors/hypervisor.go
@@ -7,29 +7,35 @@ import (
 
 // Hypervisor acts as a catch-all for "an entity that exposes access to manage
 // a virtual machine".
-//
-// ListNodes returns a list of identifiers for the nodes present on the
-// hypervisor.
-//
-// ResolveNode will use the contents of the provided &hope.Node, and will
-// return a new &hope.Node that can be used as though it were a physical
-// machine on the network.
-//
-// UnderlyingNode returns the base object used to create the hypervisor.
 type Hypervisor interface {
 	ListNodes() ([]string, error)
+
+	// Ask the hypervisor for the host of the node, and return a new node with
+	// reachable IP in its host field.
 	ResolveNode(node hope.Node) (hope.Node, error)
+
+	// Returns the base object used to create the hypervisor.
 	UnderlyingNode() (hope.Node, error)
 
+	// Copy an image from the packer cache to all hypervisors it should exist
+	// on.
 	CopyImage(packer.JsonSpec, hope.VMs, hope.VMImageSpec) error
+
+	// Create an image using the given image spec.
 	CreateImage(hope.VMs, hope.VMImageSpec, []string, bool) (*packer.JsonSpec, error)
+
+	// Create a node from the given image spec.
 	CreateNode(hope.Node, hope.VMs, hope.VMImageSpec) error
 
+	// Start the VM identified by the given value.
 	StartVM(string) error
+
+	// Start the VM identified by the given value.
 	StopVM(string) error
 
-	// Should these interfaces also take a hope.Node, just for consistency's
-	//   sake?
+	// Delete the VM identified by the given value.
 	DeleteVM(string) error
+
+	// Get the IP address of the VM identified by the given value.
 	VMIPAddress(string) (string, error)
 }

--- a/pkg/hope/hypervisors/hypervisor.go
+++ b/pkg/hope/hypervisors/hypervisor.go
@@ -8,6 +8,10 @@ import (
 // Hypervisor acts as a catch-all for "an entity that exposes access to manage
 // a virtual machine".
 type Hypervisor interface {
+	// Initialize using the provided Node.
+	Initialize(hope.Node) error
+
+	// Return a list of identifiers for the nodes present on the hypervisor.
 	ListNodes() ([]string, error)
 
 	// Ask the hypervisor for the host of the node, and return a new node with

--- a/pkg/hope/hypervisors/hypervisor_factory.go
+++ b/pkg/hope/hypervisors/hypervisor_factory.go
@@ -21,6 +21,8 @@ func ToHypervisor(node hope.Node) (Hypervisor, error) {
 		return nil, fmt.Errorf("failed to resolve hypervisor engine: %s", node.Engine)
 	}
 
-	rv.Initialize(node)
+	if err := rv.Initialize(node); err != nil {
+		return nil, err
+	}
 	return rv, nil
 }

--- a/pkg/hope/hypervisors/hypervisor_factory.go
+++ b/pkg/hope/hypervisors/hypervisor_factory.go
@@ -13,10 +13,14 @@ func ToHypervisor(node hope.Node) (Hypervisor, error) {
 		return nil, fmt.Errorf("node named %s is not a hypervisor", node.Name)
 	}
 
+	var rv Hypervisor = nil
 	switch node.Engine {
 	case "esxi":
-		return &EsxiHypervisor{node}, nil
+		rv = &EsxiHypervisor{}
+	default:
+		return nil, fmt.Errorf("failed to resolve hypervisor engine: %s", node.Engine)
 	}
 
-	return nil, fmt.Errorf("failed to resolve hypervisor engine: %s", node.Engine)
+	rv.Initialize(node)
+	return rv, nil
 }


### PR DESCRIPTION
Gives implementers of `Hypervisor` an opportunity to do some initialization, and even determine they're improperly configured before returning them out of the factory function. 