### PR TITLE
Prevent linting errors from getting into master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,10 @@ ARG VERSION UnspecifiedContainerVersion
 
 COPY . .
 
-RUN make test && make
+RUN \
+  make test && \
+  make && \
+  gofmt -l . | grep . && echo "go fmt wants to make changes; run go fmt and fix linting errors." && exit 1 || exit 0
 
 
 FROM debian:12

--- a/cmd/hope/utils/nodes_test.go
+++ b/cmd/hope/utils/nodes_test.go
@@ -100,7 +100,7 @@ func (m *MockHypervisor) Initialize(node hope.Node) error {
 }
 
 func (m *MockHypervisor) ListNodes() ([]string, error) {
-	nodes := []string{	
+	nodes := []string{
 		loadBalancerNode.Name,
 		master1Node.Name,
 		master2Node.Name,

--- a/pkg/hope/kubectl_jobs_test.go
+++ b/pkg/hope/kubectl_jobs_test.go
@@ -18,7 +18,7 @@ import (
 type KubectlJobsTestSuite struct {
 	suite.Suite
 
-	originalGetKubectl func(kubectl *kubeutil.Kubectl, args ...string) (string, error) 
+	originalGetKubectl func(kubectl *kubeutil.Kubectl, args ...string) (string, error)
 }
 
 func (s *KubectlJobsTestSuite) SetupTest() {


### PR DESCRIPTION
Adds a format checking step to the Dockerfile, so that linting errors result in build failures. 