### PR TITLE
Removes the ability to copy images from one hypervisor to another

### DIFF
--- a/cmd/hope/utils/nodes_test.go
+++ b/cmd/hope/utils/nodes_test.go
@@ -120,12 +120,8 @@ func (m *MockHypervisor) UnderlyingNode() (hope.Node, error) {
 	return m.node, nil
 }
 
-func (m *MockHypervisor) CopyImage(a packer.JsonSpec, b hope.VMs, c hope.VMImageSpec) error {
+func (m *MockHypervisor) CreateImage(a hope.VMs, b hope.VMImageSpec, c []string, d bool) error {
 	return nil
-}
-
-func (m *MockHypervisor) CreateImage(a hope.VMs, b hope.VMImageSpec, c []string, d bool) (*packer.JsonSpec, error) {
-	return nil, nil
 }
 
 func (m *MockHypervisor) CreateNode(a hope.Node, b hope.VMs, c hope.VMImageSpec) error {

--- a/cmd/hope/vm/image.go
+++ b/cmd/hope/vm/image.go
@@ -35,13 +35,6 @@ var imageCmd = &cobra.Command{
 			return err
 		}
 
-		// Each image that's made will be copied to all hypervisors that
-		//   accept that image.
-		hypervisors, err := utils.GetHypervisors()
-		if err != nil {
-			return err
-		}
-
 		log.Debugf("Creating VM %s using %d hypervisors", vm.Name, len(vm.Hypervisors))
 		for _, hypervisorName := range vm.Hypervisors {
 			hypervisor, err := utils.GetHypervisor(hypervisorName)
@@ -49,17 +42,9 @@ var imageCmd = &cobra.Command{
 				return err
 			}
 
-			packerSpec, err := hypervisor.CreateImage(vms, *vm, *imageCmdParameterSlice, imageCmdForceFlag)
-			if err != nil {
+			if err := hypervisor.CreateImage(vms, *vm, *imageCmdParameterSlice, imageCmdForceFlag); err != nil {
 				return err
 			}
-
-			for _, hv := range hypervisors {
-				if err := hv.CopyImage(*packerSpec, vms, *vm); err != nil {
-					return err
-				}
-			}
-
 		}
 
 		return nil

--- a/pkg/hope/hypervisors/hypervisor.go
+++ b/pkg/hope/hypervisors/hypervisor.go
@@ -2,7 +2,6 @@ package hypervisors
 
 import (
 	"github.com/Eagerod/hope/pkg/hope"
-	"github.com/Eagerod/hope/pkg/packer"
 )
 
 // Hypervisor acts as a catch-all for "an entity that exposes access to manage
@@ -21,12 +20,8 @@ type Hypervisor interface {
 	// Returns the base object used to create the hypervisor.
 	UnderlyingNode() (hope.Node, error)
 
-	// Copy an image from the packer cache to all hypervisors it should exist
-	// on.
-	CopyImage(packer.JsonSpec, hope.VMs, hope.VMImageSpec) error
-
 	// Create an image using the given image spec.
-	CreateImage(hope.VMs, hope.VMImageSpec, []string, bool) (*packer.JsonSpec, error)
+	CreateImage(hope.VMs, hope.VMImageSpec, []string, bool) error
 
 	// Create a node from the given image spec.
 	CreateNode(hope.Node, hope.VMs, hope.VMImageSpec) error


### PR DESCRIPTION
Wrote https://github.com/Eagerod/hope/pull/80/files#r1967049955 because it seemed like a weird thing to need to do, expect some cases where a hypervisor wouldn't be able to support copying images. It feels like this was built on the faulty assumption that images would always be written to the client's packer cache, when it's perfectly valid for it to live on the hypervisor after being built.

This got me thinking -- maybe the `CopyImage` feature is just out of place in general. If I run two different hypervisors for who knows what reason (peered networks between cloud + local?), the idea of copying an image between hypervisors doesn't makes sense. 

The implementation seems to have been buggy all along, copying every image to all hypervisors in `hope.yaml`, disregarding their `engine`. 