### PR TITLE
Fixes VM creation when image not defined in hopefile

### DIFF
--- a/cmd/hope/vm/create.go
+++ b/cmd/hope/vm/create.go
@@ -1,12 +1,15 @@
 package vm
 
 import (
+	"fmt"
+)
+
+import (
 	"github.com/spf13/cobra"
 )
 
 import (
 	"github.com/Eagerod/hope/cmd/hope/utils"
-	"github.com/Eagerod/hope/pkg/hope"
 )
 
 var createCmd = &cobra.Command{
@@ -15,7 +18,7 @@ var createCmd = &cobra.Command{
 	Long:  "Creates the named node as a VM using its defined hypervisor.\n\nArgs:\n  image-name: The name of the image from which to create a VM\n  node-name: The node to create from the image",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		vmName := args[0]
+		imageName := args[0]
 		nodeName := args[1]
 
 		node, err := utils.GetBareNode(nodeName)
@@ -33,14 +36,12 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		var vm hope.VMImageSpec
 		for _, aVm := range vms.Images {
-			if aVm.Name == vmName {
-				vm = aVm
-				break
+			if aVm.Name == imageName {
+				return hypervisor.CreateNode(node, vms, aVm)
 			}
 		}
 
-		return hypervisor.CreateNode(node, vms, vm)
+		return fmt.Errorf("failed to find an image called %s in hope file", imageName)
 	},
 }


### PR DESCRIPTION
Currently fails by passing an empty string into the `CreateNode` function, which could probably be a valid image name in some circumstances I can't think of, but it should be deliberate by having an image with no name, rather than running over the whole set of vms and using a zero-struct. 