### PR TITLE
Allows Hypervisors to claim images already exist to avoid recreation.

### DIFF
--- a/cmd/hope/utils/nodes.go
+++ b/cmd/hope/utils/nodes.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"errors"
 	"fmt"
-	"slices"
 )
 
 import (
@@ -202,12 +201,12 @@ func GetAvailableMasters() ([]hope.Node, error) {
 			return nil, err
 		}
 
-		hvNodes, err := hv.ListNodes()
+		hvHasNode, err := hypervisors.HasNode(hv, node.Name)
 		if err != nil {
 			return nil, err
 		}
 
-		if slices.Contains(hvNodes, node.Name) {
+		if hvHasNode {
 			exNode, err := expandHypervisor(node)
 			if err != nil {
 				return nil, err

--- a/cmd/hope/utils/nodes.go
+++ b/cmd/hope/utils/nodes.go
@@ -15,8 +15,6 @@ import (
 	"github.com/Eagerod/hope/pkg/kubeutil"
 )
 
-var toHypervisor func(hope.Node) (hypervisors.Hypervisor, error) = hypervisors.ToHypervisor
-
 func getNodes() ([]hope.Node, error) {
 	var nodes []hope.Node
 	err := viper.UnmarshalKey("nodes", &nodes)
@@ -133,7 +131,7 @@ func GetHypervisors() ([]hypervisors.Hypervisor, error) {
 
 	for _, node := range nodes {
 		if node.IsHypervisor() {
-			hypervisor, err := toHypervisor(node)
+			hypervisor, err := hypervisors.ToHypervisor(node)
 			if err != nil {
 				return nil, err
 			}
@@ -167,7 +165,7 @@ func GetHypervisor(name string) (hypervisors.Hypervisor, error) {
 
 	for _, node := range nodes {
 		if node.Name == name {
-			return toHypervisor(node)
+			return hypervisors.ToHypervisor(node)
 		}
 	}
 

--- a/cmd/hope/utils/nodes_test.go
+++ b/cmd/hope/utils/nodes_test.go
@@ -88,8 +88,6 @@ var testNodes []hope.Node = []hope.Node{
 	worker1Node,
 }
 
-var oldToHypervisor func(hope.Node) (hypervisors.Hypervisor, error) = toHypervisor
-
 type MockHypervisor struct {
 	node hope.Node
 }
@@ -178,14 +176,17 @@ func toHypervisorStub(node hope.Node) (hypervisors.Hypervisor, error) {
 // function.
 type NodesTestSuite struct {
 	suite.Suite
+
+	originalToHypervisor hypervisors.ToHypervisorFactoryFunc
 }
 
 func (s *NodesTestSuite) SetupTest() {
-	toHypervisor = toHypervisorStub
+	s.originalToHypervisor = hypervisors.ToHypervisor
+	hypervisors.ToHypervisor = toHypervisorStub
 }
 
 func (s *NodesTestSuite) TeardownTest() {
-	toHypervisor = oldToHypervisor
+	hypervisors.ToHypervisor = s.originalToHypervisor
 }
 
 // Actual test method to run the suite

--- a/cmd/hope/utils/nodes_test.go
+++ b/cmd/hope/utils/nodes_test.go
@@ -109,6 +109,22 @@ func (m *MockHypervisor) ListNodes() ([]string, error) {
 	return nodes, nil
 }
 
+func (m *MockHypervisor) ListBuiltImages(vms hope.VMs) ([]string, error) {
+	nodes := []string{
+		"load-balancer",
+		"kubernetes-node",
+	}
+	return nodes, nil
+}
+
+func (m *MockHypervisor) ListAvailableImages(vms hope.VMs) ([]string, error) {
+	nodes := []string{
+		"load-balancer",
+		"kubernetes-node",
+	}
+	return nodes, nil
+}
+
 func (m *MockHypervisor) ResolveNode(node hope.Node) (hope.Node, error) {
 	node.Hypervisor = ""
 	node.Host = node.Name

--- a/pkg/hope/hypervisors/esxi_hypervisor.go
+++ b/pkg/hope/hypervisors/esxi_hypervisor.go
@@ -78,12 +78,19 @@ func (hyp *EsxiHypervisor) ListBuiltImages(vms hope.VMs) ([]string, error) {
 func (hyp *EsxiHypervisor) ListAvailableImages(vms hope.VMs) ([]string, error) {
 	remoteVmfsPath := path.Join("/", "vmfs", "volumes", hyp.node.Datastore, "ovfs")
 
-	output, err := ssh.GetSSH(hyp.node.ConnectionString(), "find", remoteVmfsPath, "-type", "d")
+	output, err := ssh.GetSSH(hyp.node.ConnectionString(), "find", remoteVmfsPath, "-type", "d", "-maxdepth", "1")
 	if err != nil {
 		return nil, err
 	}
 
-	return strings.Split(output, "\n"), nil
+	retVal := []string{}
+	trimPrefix := remoteVmfsPath + "/"
+	for _, fullpath := range strings.Split(output, "\n") {
+		relPath := strings.TrimPrefix(fullpath, trimPrefix)
+		retVal = append(retVal, relPath)
+	}
+
+	return retVal, nil
 }
 
 func (hyp *EsxiHypervisor) ResolveNode(node hope.Node) (hope.Node, error) {

--- a/pkg/hope/hypervisors/hypervisor.go
+++ b/pkg/hope/hypervisors/hypervisor.go
@@ -38,6 +38,17 @@ type Hypervisor interface {
 	// Return a list of identifiers for the nodes present on the hypervisor.
 	ListNodes() ([]string, error)
 
+	// Return a list of identifiers for the images available to be copied to
+	// the hypervisor.
+	// Images in this list may not be in a state where they can be created
+	// using `CreateNode` yet, and may still need to be copied to the
+	// hypervisor
+	ListBuiltImages(hope.VMs) ([]string, error)
+
+	// Return a list of identifiers for image on the hypervisor that could be
+	// cloned/created right now.
+	ListAvailableImages(hope.VMs) ([]string, error)
+
 	// Ask the hypervisor for the host of the node, and return a new node with
 	// reachable IP in its host field.
 	ResolveNode(node hope.Node) (hope.Node, error)
@@ -122,4 +133,22 @@ func HasNode(hv Hypervisor, node string) (bool, error) {
 	}
 
 	return slices.Contains(hvNodes, node), nil
+}
+
+func HasBuiltImage(hv Hypervisor, vms hope.VMs, imageName string) (bool, error) {
+	hvImages, err := hv.ListBuiltImages(vms)
+	if err != nil {
+		return false, err
+	}
+
+	return slices.Contains(hvImages, imageName), nil
+}
+
+func HasAvailableImage(hv Hypervisor, vms hope.VMs, imageName string) (bool, error) {
+	hvImages, err := hv.ListAvailableImages(vms)
+	if err != nil {
+		return false, err
+	}
+
+	return slices.Contains(hvImages, imageName), nil
 }

--- a/pkg/hope/hypervisors/hypervisor.go
+++ b/pkg/hope/hypervisors/hypervisor.go
@@ -2,6 +2,7 @@ package hypervisors
 
 import (
 	"errors"
+	"slices"
 )
 
 import (
@@ -112,4 +113,13 @@ func GetEnginePlans(hypervisors []Hypervisor) ([]EngineBuildPlan, error) {
 	}
 
 	return retVal, nil
+}
+
+func HasNode(hv Hypervisor, node string) (bool, error) {
+	hvNodes, err := hv.ListNodes()
+	if err != nil {
+		return false, err
+	}
+
+	return slices.Contains(hvNodes, node), nil
 }

--- a/pkg/hope/hypervisors/hypervisor_factory.go
+++ b/pkg/hope/hypervisors/hypervisor_factory.go
@@ -8,7 +8,9 @@ import (
 	"github.com/Eagerod/hope/pkg/hope"
 )
 
-func ToHypervisor(node hope.Node) (Hypervisor, error) {
+type ToHypervisorFactoryFunc func(hope.Node) (Hypervisor, error)
+
+var ToHypervisor ToHypervisorFactoryFunc = func(node hope.Node) (Hypervisor, error) {
 	if !node.IsHypervisor() {
 		return nil, fmt.Errorf("node named %s is not a hypervisor", node.Name)
 	}


### PR DESCRIPTION
Adds the concept of available images, and built images, so that hypervisors with different `CopyImageMode`s can enable users to avoid recreating existing resources.

Cleans up some surrounding hypervisor references.