### PR TITLE
Adds the ability for nodes to have defined properties

### DIFF
--- a/cmd/hope/node/init.go
+++ b/cmd/hope/node/init.go
@@ -52,7 +52,7 @@ var initCmd = &cobra.Command{
 
 		var lbp *hope.Node = nil
 		loadBalancer, err := utils.GetLoadBalancer()
-		if _, ok := err.(utils.NodeNotFoundError); err != nil && !ok {
+		if _, ok := err.(*utils.NodeNotFoundError); err != nil && !ok {
 			return err
 		} else if !ok {
 			lbp = &loadBalancer

--- a/cmd/hope/node/init.go
+++ b/cmd/hope/node/init.go
@@ -52,7 +52,7 @@ var initCmd = &cobra.Command{
 
 		var lbp *hope.Node = nil
 		loadBalancer, err := utils.GetLoadBalancer()
-		if _, ok := err.(utils.ErrNodeNotFound); err != nil && !ok {
+		if _, ok := err.(utils.NodeNotFoundError); err != nil && !ok {
 			return err
 		} else if !ok {
 			lbp = &loadBalancer

--- a/cmd/hope/node/init.go
+++ b/cmd/hope/node/init.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -51,10 +52,11 @@ var initCmd = &cobra.Command{
 		}
 
 		var lbp *hope.Node = nil
+		var nnf *utils.NodeNotFoundError
 		loadBalancer, err := utils.GetLoadBalancer()
-		if _, ok := err.(*utils.NodeNotFoundError); err != nil && !ok {
+		if err != nil && !errors.As(err, &nnf) {
 			return err
-		} else if !ok {
+		} else if err == nil {
 			lbp = &loadBalancer
 		}
 

--- a/cmd/hope/node/init.go
+++ b/cmd/hope/node/init.go
@@ -50,15 +50,14 @@ var initCmd = &cobra.Command{
 			return err
 		}
 
-		loadBalancer, err := utils.GetLoadBalancer()
-		if err != nil && loadBalancer != (hope.Node{}) {
-			return err
-		}
-
 		var lbp *hope.Node = nil
-		if loadBalancer != (hope.Node{}) {
+		loadBalancer, err := utils.GetLoadBalancer()
+		if _, ok := err.(utils.ErrNodeNotFound); err != nil && !ok {
+			return err
+		} else if !ok {
 			lbp = &loadBalancer
 		}
+
 		loadBalancerHost := viper.GetString("load_balancer_host")
 
 		if node.IsMasterAndNode() {

--- a/cmd/hope/utils/nodes.go
+++ b/cmd/hope/utils/nodes.go
@@ -15,15 +15,15 @@ import (
 	"github.com/Eagerod/hope/pkg/kubeutil"
 )
 
-type ErrNodeNotFound struct {
+type NodeNotFoundError struct {
 	node string
 }
 
-func NewErrNodeNotFound(node string) error {
-	return ErrNodeNotFound{node}
+func NewNodeNotFoundError(node string) error {
+	return NodeNotFoundError{node}
 }
 
-func (e ErrNodeNotFound) Error() string {
+func (e NodeNotFoundError) Error() string {
 	return fmt.Sprintf("failed to find node: %s", e.node)
 }
 
@@ -77,7 +77,7 @@ func GetBareNode(name string) (hope.Node, error) {
 		}
 	}
 
-	return hope.Node{}, NewErrNodeNotFound(name)
+	return hope.Node{}, NewNodeNotFoundError(name)
 }
 
 func GetBareNodeTypes(types []string) ([]hope.Node, error) {
@@ -268,7 +268,7 @@ func GetLoadBalancer() (hope.Node, error) {
 		}
 	}
 
-	return hope.Node{}, NewErrNodeNotFound("load-balancer")
+	return hope.Node{}, NewNodeNotFoundError("load-balancer")
 }
 
 func HypervisorForNodeNamed(name string) (*hypervisors.Hypervisor, error) {

--- a/cmd/hope/utils/nodes.go
+++ b/cmd/hope/utils/nodes.go
@@ -20,10 +20,10 @@ type NodeNotFoundError struct {
 }
 
 func NewNodeNotFoundError(node string) error {
-	return NodeNotFoundError{node}
+	return &NodeNotFoundError{node}
 }
 
-func (e NodeNotFoundError) Error() string {
+func (e *NodeNotFoundError) Error() string {
 	return fmt.Sprintf("failed to find node: %s", e.node)
 }
 

--- a/cmd/hope/utils/nodes.go
+++ b/cmd/hope/utils/nodes.go
@@ -15,6 +15,18 @@ import (
 	"github.com/Eagerod/hope/pkg/kubeutil"
 )
 
+type ErrNodeNotFound struct {
+	node string
+}
+
+func NewErrNodeNotFound(node string) error {
+	return ErrNodeNotFound{node}
+}
+
+func (e ErrNodeNotFound) Error() string {
+	return fmt.Sprintf("failed to find node: %s", e.node)
+}
+
 func getNodes() ([]hope.Node, error) {
 	var nodes []hope.Node
 	err := viper.UnmarshalKey("nodes", &nodes)
@@ -65,7 +77,7 @@ func GetBareNode(name string) (hope.Node, error) {
 		}
 	}
 
-	return hope.Node{}, fmt.Errorf("failed to find a node named %s", name)
+	return hope.Node{}, NewErrNodeNotFound(name)
 }
 
 func GetBareNodeTypes(types []string) ([]hope.Node, error) {
@@ -256,10 +268,7 @@ func GetLoadBalancer() (hope.Node, error) {
 		}
 	}
 
-	// This feels dirty, and a little broken.
-	// Maybe need a dedicated NodeNotFound kind of error that can be handled
-	//   independently of other errors if desired.
-	return hope.Node{}, nil
+	return hope.Node{}, NewErrNodeNotFound("load-balancer")
 }
 
 func HypervisorForNodeNamed(name string) (*hypervisors.Hypervisor, error) {

--- a/cmd/hope/utils/nodes_test.go
+++ b/cmd/hope/utils/nodes_test.go
@@ -37,6 +37,9 @@ var beast1Node hope.Node = hope.Node{
 	User:      "root",
 	Datastore: "Main",
 	Network:   "VM Network",
+	Parameters: []string{
+		"INSECURE=true",
+	},
 }
 var loadBalancerNode hope.Node = hope.Node{
 	Name:       "test-load-balancer",

--- a/cmd/hope/utils/nodes_test.go
+++ b/cmd/hope/utils/nodes_test.go
@@ -243,7 +243,7 @@ func (s *NodesTestSuite) TestGetNode() {
 	assert.Equal(t, expected, node)
 
 	_, err = GetNode("sets-node-01")
-	assert.Equal(t, "failed to find a node named sets-node-01", err.Error())
+	assert.Equal(t, "failed to find node: sets-node-01", err.Error())
 }
 
 func (s *NodesTestSuite) TestHasNode() {

--- a/hope.yaml
+++ b/hope.yaml
@@ -12,6 +12,8 @@ nodes:
     user: root
     datastore: Main
     network: VM Network
+    parameters:
+      - INSECURE=true
   # Master Load Balancer
   # Just one of these; manages providing a single endpoint for the set of
   #   master nodes.

--- a/pkg/hope/entities.go
+++ b/pkg/hope/entities.go
@@ -129,6 +129,7 @@ type Node struct {
 	Network    string
 	Cpu        int
 	Memory     int
+	Parameters []string
 }
 
 // VMImageSpec - Defines the structure needed to populate a Packer job to

--- a/pkg/hope/hypervisors/esxi_hypervisor.go
+++ b/pkg/hope/hypervisors/esxi_hypervisor.go
@@ -27,21 +27,21 @@ func (hyp *EsxiHypervisor) Initialize(node hope.Node) error {
 	hyp.node = node
 
 	errs := []error{}
-	for _, s := range node.Parameters {
-		key, value, _ := strings.Cut(s, "=")
-		switch key {
-		case "INSECURE":
-			switch value {
-			case "true", "1":
-				hyp.insecure = true
-			case "false", "0":
-				hyp.insecure = false
-			default:
-				errs = append(errs, fmt.Errorf("unknown value '%s' for INSECURE in ESXI hypervisor", value))
-			}
+	pm := ParameterMap(node.Parameters)
+	if insecure, ok := pm["INSECURE"]; ok {
+		switch insecure {
+		case "true", "1":
+			hyp.insecure = true
+		case "false", "0":
+			hyp.insecure = false
 		default:
-			errs = append(errs, fmt.Errorf("unknown property '%s' in ESXI hypervisor", key))
+			errs = append(errs, fmt.Errorf("unknown value '%s' for INSECURE in ESXI hypervisor", insecure))
 		}
+		delete(pm, "INSECURE")
+	}
+
+	for key := range pm {
+		errs = append(errs, fmt.Errorf("unknown property '%s' in ESXI hypervisor", key))
 	}
 
 	return errors.Join(errs...)

--- a/pkg/hope/hypervisors/esxi_hypervisor.go
+++ b/pkg/hope/hypervisors/esxi_hypervisor.go
@@ -1,6 +1,7 @@
 package hypervisors
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -18,11 +19,32 @@ import (
 
 type EsxiHypervisor struct {
 	node hope.Node
+
+	insecure bool
 }
 
 func (hyp *EsxiHypervisor) Initialize(node hope.Node) error {
 	hyp.node = node
-	return nil
+
+	errs := []error{}
+	for _, s := range node.Parameters {
+		key, value, _ := strings.Cut(s, "=")
+		switch key {
+		case "INSECURE":
+			switch value {
+			case "true", "1":
+				hyp.insecure = true
+			case "false", "0":
+				hyp.insecure = false
+			default:
+				errs = append(errs, fmt.Errorf("unknown value '%s' for INSECURE in ESXI hypervisor", value))
+			}
+		default:
+			errs = append(errs, fmt.Errorf("unknown property '%s' in ESXI hypervisor", key))
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 func (hyp *EsxiHypervisor) CopyImageMode() CopyImageMode {
@@ -138,10 +160,16 @@ func (hyp *EsxiHypervisor) CreateNode(node hope.Node, vms hope.VMs, vmImageSpec 
 		fmt.Sprintf("--net:'%s=%s'", sourceNetworkName, hyp.node.Network),
 		fmt.Sprintf("--numberOfCpus:'*'=%d", node.Cpu),
 		fmt.Sprintf("--memorySize:'*'=%d", node.Memory),
-		"--noSSLVerify",
+	}
+
+	if hyp.insecure {
+		allArgs = append(allArgs, "--noSSLVerify")
+	}
+
+	allArgs = append(allArgs, []string{
 		remoteOvfPath,
 		"vi://root@localhost",
-	}
+	}...)
 
 	// Check to see if the ESXI_ROOT_PASSWORD environment if set.
 	// If so, pass it on to the ssh invocation to help limit user

--- a/pkg/hope/hypervisors/esxi_hypervisor_test.go
+++ b/pkg/hope/hypervisors/esxi_hypervisor_test.go
@@ -77,6 +77,45 @@ func TestEsxiHypervisor(t *testing.T) {
 	suite.Run(t, new(EsxiHypervisorTestSuite))
 }
 
+func (s *EsxiHypervisorTestSuite) TestInitialize() {
+	t := s.T()
+
+	n1 := exampleEsxiHypervisorNode1
+	n1.Parameters = []string{
+		"INSECURE=true",
+	}
+
+	hyp := EsxiHypervisor{}
+	err := hyp.Initialize(n1)
+	assert.NoError(t, err)
+	assert.True(t, hyp.insecure)
+
+	n1.Parameters = []string{
+		"INSECURE=0",
+	}
+
+	hyp = EsxiHypervisor{}
+	err = hyp.Initialize(n1)
+	assert.NoError(t, err)
+	assert.False(t, hyp.insecure)
+
+	n1.Parameters = []string{
+		"insecure=0",
+	}
+
+	hyp = EsxiHypervisor{}
+	err = hyp.Initialize(n1)
+	assert.Equal(t, "unknown property 'insecure' in ESXI hypervisor", err.Error())
+
+	n1.Parameters = []string{
+		"INSECURE=yes",
+	}
+
+	hyp = EsxiHypervisor{}
+	err = hyp.Initialize(n1)
+	assert.Equal(t, "unknown value 'yes' for INSECURE in ESXI hypervisor", err.Error())
+}
+
 // Basically a smoke test, don't want to define a ton of yaml blocks to test
 // this extensively quite yet.
 func (s *EsxiHypervisorTestSuite) TestCopyImage() {

--- a/pkg/hope/hypervisors/hypervisor.go
+++ b/pkg/hope/hypervisors/hypervisor.go
@@ -3,6 +3,7 @@ package hypervisors
 import (
 	"errors"
 	"slices"
+	"strings"
 )
 
 import (
@@ -151,4 +152,15 @@ func HasAvailableImage(hv Hypervisor, vms hope.VMs, imageName string) (bool, err
 	}
 
 	return slices.Contains(hvImages, imageName), nil
+}
+
+func ParameterMap(params []string) map[string]string {
+	retVal := map[string]string{}
+
+	for _, s := range params {
+		key, value, _ := strings.Cut(s, "=")
+		retVal[key] = value
+	}
+
+	return retVal
 }


### PR DESCRIPTION
Now that Hypervisors have a formal `Initialize` function (#79), they have a little more control over receiving arbitrary input from the user. 

With this, why not allow Hypervisors to offer up some minor configurability through a list of parameters?

Doesn't offer any parsing facilities, which might be a bit of a pain.