### PR TITLE
Prevent fix command argument counts

### DIFF
--- a/cmd/hope/deploy.go
+++ b/cmd/hope/deploy.go
@@ -28,6 +28,7 @@ func initDeployCmdFlags() {
 var deployCmd = &cobra.Command{
 	Use:   "deploy [resource-name]...",
 	Short: "Deploy Kubernetes resources defined in the hope file",
+	Args:  cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var resources *[]hope.Resource
 

--- a/cmd/hope/list.go
+++ b/cmd/hope/list.go
@@ -25,6 +25,7 @@ func initListCmdFlags() {
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List resources that belong to a particular set of tags",
+	Args:  cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var resources *[]hope.Resource
 

--- a/cmd/hope/node/list.go
+++ b/cmd/hope/node/list.go
@@ -25,6 +25,7 @@ func initListCmd() {
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "lists the nodes present in the hope config file.",
+	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(*listCmdTypeSlice) == 0 {
 			*listCmdTypeSlice = []string{

--- a/cmd/hope/remove.go
+++ b/cmd/hope/remove.go
@@ -26,6 +26,7 @@ func initRemoveCmdFlags() {
 var removeCmd = &cobra.Command{
 	Use:   "remove [resource-name]...",
 	Short: "Remove Kubernetes resources defined in the hope file",
+	Args:  cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Why not?
 		if len(args) == 0 && len(*removeCmdTagSlice) == 0 {

--- a/cmd/hope/version.go
+++ b/cmd/hope/version.go
@@ -14,6 +14,7 @@ var VersionBuild string = "unstable-dev"
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Prints the version number and exits",
+	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Print straight to console, since log level shouldn't dictate
 		//   whether or not this makes it to console.


### PR DESCRIPTION
Ran into a case where I was misusing `node list`, having it error out on invalid args is a good move.